### PR TITLE
fix: skip HA Groups on PVE 9+ (closes #2)

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
@@ -15,6 +15,13 @@ public partial class ReportEngine
     {
         var sw = new SheetWriter(workbook.Worksheets.Add("Cluster"), _sheetLinks);
 
+        var pveVersion = await client.Version.GetAsync();
+        var pveMajor = int.TryParse(pveVersion.Version?.Split('.')[0], out var v) 
+                        ? v 
+                        : 0;
+                        
+        var haGroupsSupported = pveMajor < 9;
+
         var tableCount = 1  // Status
                        + (settings.Cluster.IncludeOptions ? 1 : 0)
                        + (settings.Cluster.IncludeSecurity ? 7 : 0)
@@ -26,7 +33,7 @@ public partial class ReportEngine
                        + (settings.Cluster.IncludeSdn ? 5 : 0)
                        + (settings.Cluster.IncludeMapping ? 3 : 0)
                        + (settings.Cluster.IncludePools ? 1 : 0)
-                       + (settings.Cluster.IncludeHa ? 3 : 0);
+                       + (settings.Cluster.IncludeHa ? (haGroupsSupported ? 3 : 2) : 0);
 
         var clusterStatus = (await client.Cluster.Status.GetAsync()).FirstOrDefault(a => a.Type == "cluster");
 
@@ -367,15 +374,18 @@ public partial class ReportEngine
                                a.Comment
                            }));
 
-            sw.CreateTable("HA Groups",
-                           (await client.Cluster.Ha.Groups.GetAsync()).Select(a => new
-                           {
-                               a.Group,
-                               a.Nodes,
-                               a.Nofailback,
-                               a.Restricted,
-                               a.Comment
-                           }));
+            if (haGroupsSupported)
+            {
+                sw.CreateTable("HA Groups",
+                               (await client.Cluster.Ha.Groups.GetAsync()).Select(a => new
+                               {
+                                   a.Group,
+                                   a.Nodes,
+                                   a.Nofailback,
+                                   a.Restricted,
+                                   a.Comment
+                               }));
+            }
 
             sw.CreateTable("HA Status",
                            (await client.Cluster.Ha.Status.Current.GetAsync()).Select(a => new


### PR DESCRIPTION
## Problem

PVE 9 removed the `/cluster/ha/groups` endpoint — HA groups have been migrated to rules. Running the tool against PVE 9.x caused:

```
ERROR: cannot index groups: ha groups have been migrated to rules
```

Closes #2

## Fix

- Read PVE version at startup via `client.Version.GetAsync()`
- Skip HA Groups table when PVE major version >= 9
- `tableCount` adjusted accordingly (2 tables instead of 3 for HA on PVE 9+)
- HA Resources and HA Status are still exported normally on all versions