### PR TITLE
fix: null reference on VmId when backup job has All=true

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
@@ -172,7 +172,7 @@ public partial class ReportEngine
                                a.Id,
                                a.Enabled,
                                a.All,
-                               VmId = a.VmId.Replace(",", Environment.NewLine),
+                               VmId = a.VmId?.Replace(",", Environment.NewLine),
                                a.Mode,
                                a.Storage,
                                a.StartTime,


### PR DESCRIPTION
## Summary
- Fix `NullReferenceException` on `[Cluster: Backup Jobs]` when a backup job has `All = true` and `VmId` is null
- Simple null-conditional fix: `a.VmId?.Replace(...)` instead of `a.VmId.Replace(...)`

## Related
Fixes #2 (reported by multiple users on PVE 9.x)