### PR TITLE
fix: handle null firewall logs and add Sys.Modify to required permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ All binaries on the [Releases page](https://github.com/Corsinvest/cv4pve-report/
 | **Datastore.Audit** | Read storage content and metrics | Storage systems |
 | **Pool.Audit** | Access pool information | Resource pools |
 | **Sys.Audit** | Node system information, services, disks | Cluster nodes |
+| **Sys.Modify** | APT repositories, available updates and installed package versions | Cluster nodes |
 
 
 </details>

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
@@ -349,9 +349,9 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
                        }));
     }
 
-    private static void AddLogs(SheetWriter sw, string title, IEnumerable<string> logs)
+    private static void AddLogs(SheetWriter sw, string title, IEnumerable<string>? logs)
     {
-        var list = logs.ToList();
+        var list = (logs ?? []).ToList();
 
         // Proxmox API returns "no content" string when there are no logs, 
         // so we need to check for that and return an empty list instead


### PR DESCRIPTION
Related to #10

## Changes
- **Fix null crash in Firewall Logs**: `AddLogs` now accepts `IEnumerable<string>?` and handles `null` returned by the API when the user lacks firewall log permissions — instead of crashing with `Value cannot be null (Parameter 'source')`, it produces an empty sheet
- **Docs**: add `Sys.Modify` to required permissions table in README — needed for APT repositories, updates and installed package versions