### PR TITLE
feat: add IncludeFirewallLog flag to node and guest detail settings

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
@@ -177,12 +177,12 @@ public partial class ReportEngine
         sw.Row = Math.Max(sw.Row, mainRow);
         sw.Col = 1;
 
-        var tableCount = (settings.Firewall.Enabled ? 1 : 0)  // Firewall Logs
+        var tableCount = (settings.Firewall.Enabled && settings.Guest.Detail.IncludeFirewallLog ? 1 : 0)  // Firewall Logs
                        + (settings.Guest.Detail.Tasks.Enabled ? 1 : 0);
 
         sw.ReserveIndexRows(tableCount);
 
-        if (settings.Firewall.Enabled)
+        if (settings.Firewall.Enabled && settings.Guest.Detail.IncludeFirewallLog)
         {
             pt.Step("Firewall Logs");
             AddLogs(sw,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Node.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Node.cs
@@ -164,7 +164,7 @@ public partial class ReportEngine
                        + (settings.Node.Detail.Disk.IncludeDiskDetail ? 2 : 0)   // ZFS Pools + ZFS Pool Status
                        + (settings.Node.Detail.Disk.IncludeDiskDetail ? 1 : 0)   // Directory
                        + (settings.Node.Detail.IncludeApt ? 3 : 0)               // Repositories + Updates + Versions
-                       + (settings.Firewall.Enabled ? 1 : 0)  // Firewall Logs
+                       + (settings.Firewall.Enabled && settings.Node.Detail.IncludeFirewallLog ? 1 : 0)  // Firewall Logs
                        + 1  // SSL Certificates
                        + (settings.Node.Detail.Tasks.Enabled ? 1 : 0);
 
@@ -387,7 +387,7 @@ public partial class ReportEngine
                             }));
         }
 
-        if (settings.Firewall.Enabled)
+        if (settings.Firewall.Enabled && settings.Node.Detail.IncludeFirewallLog)
         {
             pt.Step("Firewall Logs");
             AddLogs(sw,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
@@ -334,12 +334,12 @@ public partial class ReportEngine
             sw.Col = 1;
         }
 
-        var tableCount = (settings.Firewall.Enabled ? 1 : 0)  // Firewall Logs
+        var tableCount = (settings.Firewall.Enabled && settings.Guest.Detail.IncludeFirewallLog ? 1 : 0)  // Firewall Logs
                          + (settings.Guest.Detail.Tasks.Enabled ? 1 : 0);
 
         sw.ReserveIndexRows(tableCount);
 
-        if (settings.Firewall.Enabled)
+        if (settings.Firewall.Enabled && settings.Guest.Detail.IncludeFirewallLog)
         {
             pt.Step("Firewall Logs");
 

--- a/src/Corsinvest.ProxmoxVE.Report/SettingsGuestDetail.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/SettingsGuestDetail.cs
@@ -19,4 +19,9 @@ public class SettingsGuestDetail
     /// Task history settings
     /// </summary>
     public SettingsTask Tasks { get; set; } = new();
+
+    /// <summary>
+    /// Include firewall log sheet
+    /// </summary>
+    public bool IncludeFirewallLog { get; set; } = true;
 }

--- a/src/Corsinvest.ProxmoxVE.Report/SettingsNodeDetail.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/SettingsNodeDetail.cs
@@ -29,4 +29,9 @@ public class SettingsNodeDetail
     /// Include APT repositories, available updates and installed package versions
     /// </summary>
     public bool IncludeApt { get; set; } = true;
+
+    /// <summary>
+    /// Include firewall log sheet
+    /// </summary>
+    public bool IncludeFirewallLog { get; set; } = true;
 }


### PR DESCRIPTION
## Summary
- Add `IncludeFirewallLog` flag to `SettingsNodeDetail` and `SettingsGuestDetail` (default `true`)
- Allows disabling firewall log sheets per node/guest independently from `Firewall.Enabled`
- Useful to reduce API calls and skip permission requirements (`Sys.Audit` on firewall) without disabling the global firewall sheet