### PR TITLE
feat: /etc/hosts in node detail, skip offline nodes, RunParallelAsync for v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [1.7.0] — 2026-04-13
+
+### What's new
+
+- **Host file in node detail** — the host name resolution table (`/etc/hosts`) is now included in each node's detail sheet, right after the network interfaces
+- **Offline nodes** — nodes that are offline are now skipped gracefully instead of producing errors in the report
+
+---
+
 ## [1.6.0] — 2026-04-11
 
 ### Fixes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.6.0</Version>
+        <Version>1.7.0</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.11" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.11" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.13" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.13" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Per-node sheet (linked from Nodes list), with `← Back` to Nodes. Skipped entir
 |-------|----------|
 | Services | System service status |
 | Network | Interface configuration with IPv4/IPv6, bond, VLAN, OVS details |
+| /etc/hosts | Host name resolution entries |
 | Disks | Physical disk list *(if `Node.Detail.Disk.IncludeDiskDetail`)* |
 | SMART Data | SMART attributes per disk *(if `Node.Detail.Disk.IncludeSmartData`)* |
 | ZFS Pools / ZFS Pool Status | ZFS pool health, usage, vdev tree *(if `Node.Detail.Disk.IncludeDiskDetail`)* |

--- a/src/Corsinvest.ProxmoxVE.Report.Console/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Report.Console/Program.cs
@@ -11,7 +11,7 @@ using System.Text.Json;
 
 const string settingsFileName = "settings.json";
 
-var app = ConsoleHelper.CreateApp("cv4pve-report", "Report for Proxmox VE");
+var app = ConsoleHelper.CreateApp("Report for Proxmox VE");
 
 var logLevel = app.DebugIsActive()
                 ? LogLevel.Debug

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
@@ -333,13 +333,9 @@ public partial class ReportEngine
                            a.Type,
                        }));
 
-        var subnetSem = CreateSemaphore();
-        var subnetResults = await Task.WhenAll(vnetsTask.Result.Select(async vnet =>
-        {
-            await subnetSem.WaitAsync();
-            try { return (vnet, subs: await client.Cluster.Sdn.Vnets[vnet.Vnet].Subnets.GetAsync()); }
-            finally { subnetSem.Release(); }
-        }));
+        var subnetResults = await RunParallelAsync(vnetsTask.Result,
+                                                   async vnet => (vnet,
+                                                                  subs: await client.Cluster.Sdn.Vnets[vnet.Vnet].Subnets.GetAsync()));
         sw.CreateTable("SDN Subnets",
                        subnetResults.SelectMany(r => r.subs.Select(subnet => new
                        {
@@ -378,13 +374,8 @@ public partial class ReportEngine
                        }));
 
         ReportGlobal("Cluster: Pools");
-        var poolSem = CreateSemaphore();
-        var poolResults = await Task.WhenAll(poolsTask.Result.Select(async pool =>
-        {
-            await poolSem.WaitAsync();
-            try { var detail = await client.Pools[pool.Id].GetAsync(); return (pool, detail.Members); }
-            finally { poolSem.Release(); }
-        }));
+        var poolResults = await RunParallelAsync(poolsTask.Result,
+                                                 async pool => { var detail = await client.Pools[pool.Id].GetAsync(); return (pool, detail.Members); });
         sw.CreateTable("Pools",
                        poolResults.SelectMany(r => r.Members.Select(member => new
                        {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
@@ -65,14 +65,8 @@ public partial class ReportEngine
         var items = new List<dynamic>();
         var pt = new ProgressTracker(_progress, resources.Count);
 
-        var semaphore = CreateSemaphore();
-        var tasks = resources.Select(async item =>
-        {
-            await semaphore.WaitAsync();
-            try { return await FetchCtDataAsync(item, pt); }
-            finally { semaphore.Release(); }
-        });
-        var results = (await Task.WhenAll(tasks)).OrderBy(d => d.Item.Id).ToList();
+        var results = (await RunParallelAsync(resources, item => FetchCtDataAsync(item, pt)))
+                            .OrderBy(d => d.Item.Id).ToList();
 
         foreach (var d in results)
         {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Firewall.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Firewall.cs
@@ -18,6 +18,8 @@ public partial class ReportEngine
         if (!settings.Firewall.Enabled) { return 0; }
 
         var sw = CreateSheetWriter(workbook, "Firewall");
+        sw.ReserveIndexRows(3);
+
         IXLTable? rulesTable = null;
         IXLTable? aliasTable = null;
         IXLTable? ipSetTable = null;
@@ -48,15 +50,7 @@ public partial class ReportEngine
             }).ToList();
 
             rulesCount += rows.Count;
-            if (rulesTable == null)
-            {
-                sw!.ReserveIndexRows(3);
-                rulesTable = sw.CreateTable("Firewall Rules", rows);
-            }
-            else
-            {
-                sw!.AppendData(rulesTable, rows);
-            }
+            sw.CreateOrAddTable(ref rulesTable, "Firewall Rules", rows);
         }
 
         void AppendAliases(string scopeType, string scope, string scopeName, IEnumerable<FirewallAlias> aliases)
@@ -85,8 +79,6 @@ public partial class ReportEngine
                                        CommentWrap = a.Comment,
                                    }).ToList());
 
-        var semaphore = CreateSemaphore();
-
         // Cluster firewall
         ReportGlobal("Firewall: Cluster");
         var clusterRulesTask = client.Cluster.Firewall.Rules.GetAsync();
@@ -99,32 +91,24 @@ public partial class ReportEngine
         AppendIpSets("cluster", "cluster", "", clusterIpSetsTask.Result);
 
         // Nodes firewall — parallel
-        var nodeTasks = GetResources(ClusterResourceType.Node)
-                              .Where(a => !a.IsUnknown)
-                              .Select(async item =>
-        {
-            await semaphore.WaitAsync();
-            try
+        var nodeFirewallResults = await RunParallelAsync(
+            GetResources(ClusterResourceType.Node).Where(a => !a.IsUnknown),
+            async item =>
             {
                 ReportGlobal($"Firewall: Node {item.Node}");
                 return (scope: item.Node,
                         rules: await client.Nodes[item.Node].Firewall.Rules.GetAsync());
-            }
-            finally { semaphore.Release(); }
-        });
+            });
 
-        foreach (var (scope, rules) in (await Task.WhenAll(nodeTasks)).OrderBy(r => r.scope))
+        foreach (var (scope, rules) in nodeFirewallResults.OrderBy(r => r.scope))
         {
             AppendRules("node", scope, "", rules);
         }
 
         // VMs and CTs firewall — parallel
-        var guestTasks = GetResources(ClusterResourceType.Vm)
-                               .Where(a => !a.IsUnknown)
-                               .Select(async item =>
-        {
-            await semaphore.WaitAsync();
-            try
+        var guestFirewallResults = await RunParallelAsync(
+            GetResources(ClusterResourceType.Vm).Where(a => !a.IsUnknown),
+            async item =>
             {
                 ReportGlobal($"Firewall: {item.VmType} {item.VmId}");
 
@@ -155,11 +139,9 @@ public partial class ReportEngine
                         rules: rulesTask.Result,
                         aliases: aliasesTask.Result,
                         ipSets: ipSetsTask.Result);
-            }
-            finally { semaphore.Release(); }
-        });
+            });
 
-        foreach (var (scopeType, scope, scopeName, rules, aliases, ipSets) in (await Task.WhenAll(guestTasks)).OrderBy(r => r.scope))
+        foreach (var (scopeType, scope, scopeName, rules, aliases, ipSets) in guestFirewallResults.OrderBy(r => r.scope))
         {
             AppendRules(scopeType, scope, scopeName, rules);
             AppendAliases(scopeType, scope, scopeName, aliases);

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Node.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Node.cs
@@ -4,6 +4,7 @@
  */
 
 using ClosedXML.Excel;
+using Corsinvest.ProxmoxVE.Api;
 using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
@@ -28,7 +29,7 @@ public partial class ReportEngine
     {
         pt.Next(item);
 
-        if (item.IsUnknown) { return new NodeFetchData { Item = item }; }
+        if (item.IsUnknown || !item.IsOnline) { return new NodeFetchData { Item = item }; }
 
         pt.Step("Status/Version/Subscription/DNS/Time/Network");
         var node = client.Nodes[item.Node];
@@ -63,15 +64,8 @@ public partial class ReportEngine
 
         var pt = new ProgressTracker(_progress, filtered.Count);
 
-        var semaphore = CreateSemaphore();
-        var tasks = filtered.Select(async item =>
-        {
-            await semaphore.WaitAsync();
-            try { return await FetchNodeDataAsync(item, pt); }
-            finally { semaphore.Release(); }
-        });
-
-        var results = (await Task.WhenAll(tasks)).OrderBy(a => a.Item.Id).ToList();
+        var results = (await RunParallelAsync(filtered, item => FetchNodeDataAsync(item, pt)))
+                            .OrderBy(a => a.Item.Id).ToList();
 
         foreach (var d in results)
         {
@@ -127,7 +121,7 @@ public partial class ReportEngine
                 d.Dns?.Dns3,
             });
 
-            if (!d.Item.IsUnknown && settings.Node.Detail.Enabled)
+            if (!d.Item.IsUnknown && d.Item.IsOnline && settings.Node.Detail.Enabled)
             {
                 await AddNodeDetailAsync(workbook, d, pt);
             }
@@ -186,15 +180,17 @@ public partial class ReportEngine
                        + (settings.Node.Detail.IncludeApt ? 3 : 0)               // Repositories + Updates + Versions
                        + (settings.Firewall.Enabled && settings.Node.Detail.IncludeFirewallLog ? 1 : 0)  // Firewall Logs
                        + 1  // SSL Certificates
-                       + (settings.Node.Detail.Tasks.Enabled ? 1 : 0);
+                       + (settings.Node.Detail.Tasks.Enabled ? 1 : 0)
+                       + 1;                                                        // /etc/hosts
 
         sw.ReserveIndexRows(tableCount);
 
-        pt.Step("Services/SSL Certificates");
+        pt.Step("Services/SSL Certificates/Hosts");
         var servicesTask = client.Nodes[node].Services.GetAsync();
         var certificatesTask = client.Nodes[node].Certificates.Info.GetAsync();
+        var hostsTask = client.Nodes[node].Hosts.GetEtcHosts();
 
-        await Task.WhenAll(servicesTask, certificatesTask);
+        await Task.WhenAll(servicesTask, certificatesTask, hostsTask);
 
         sw.CreateTable("Services",
                        servicesTask.Result.Select(a => new
@@ -254,6 +250,22 @@ public partial class ReportEngine
                        }),
                        tbl => sw.RegisterNetworkLinks(tbl, node));
 
+        sw.CreateTable("/etc/hosts",
+                       ((string)hostsTask.Result.ToData().data)
+                                .Split('\n')
+                                .Select(a => a.Trim())
+                                .Where(a => a.Length > 0 && !a.StartsWith('#'))
+                                .Select(a =>
+                                {
+                                    var parts = a.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries);
+                                    return new
+                                    {
+                                        IP = parts[0],
+                                        HostnamesWrap = parts.Skip(1).JoinAsString(Environment.NewLine)
+                                    };
+                                })
+                                .ToList());
+
         if (settings.Node.Detail.Disk.IncludeDiskDetail || settings.Node.Detail.Disk.IncludeSmartData)
         {
             var disksData = await client.Nodes[node].Disks.List.GetAsync(include_partitions: true);
@@ -287,13 +299,7 @@ public partial class ReportEngine
             {
                 pt.Step("S.M.A.R.T. Data");
                 var rootDisks = disksData.Where(a => string.IsNullOrEmpty(a.Parent)).ToList();
-                var sem = CreateSemaphore();
-                var smartResults = await Task.WhenAll(rootDisks.Select(async d =>
-                {
-                    await sem.WaitAsync();
-                    try { return await client.GetDiskSmart(node, d.DevPath); }
-                    finally { sem.Release(); }
-                }));
+                var smartResults = await RunParallelAsync(rootDisks, d => client.GetDiskSmart(node, d.DevPath));
 
                 sw.CreateTable("S.M.A.R.T. Data",
                                rootDisks.Zip(smartResults, (disk, smart) => (smart.Attributes ?? []).Select(attr => new
@@ -334,13 +340,7 @@ public partial class ReportEngine
                                }));
 
                 var zfsPoolList = zfsPoolsListTask.Result.ToList();
-                var zfsSem = CreateSemaphore();
-                var zfsPoolDetails = await Task.WhenAll(zfsPoolList.Select(async p =>
-                {
-                    await zfsSem.WaitAsync();
-                    try { return await client.Nodes[node].Disks.Zfs[p.Name].GetAsync(); }
-                    finally { zfsSem.Release(); }
-                }));
+                var zfsPoolDetails = await RunParallelAsync(zfsPoolList, p => client.Nodes[node].Disks.Zfs[p.Name].GetAsync());
 
                 sw.CreateTable("ZFS Pools", zfsPoolList.Zip(zfsPoolDetails, (pool, poolData) => new
                 {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Partitions.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Partitions.cs
@@ -12,7 +12,7 @@ namespace Corsinvest.ProxmoxVE.Report;
 public partial class ReportEngine
 {
     private void AppendPartitionRows(ClusterResource vm,
-                                     IEnumerable<VmQemuAgentGetFsInfo.ResultInt> partitions)
+                                     IEnumerable<VmQemuAgentGetFsInfo.ResultInfo> partitions)
     {
         if (!settings.Guest.IncludePartitionsSheet) { return; }
         _pendingPartitionRows.Add((vm, partitions));

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Replication.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Replication.cs
@@ -22,43 +22,37 @@ public partial class ReportEngine
 
         if (nodes.Count == 0) { return 0; }
 
-        var sem = CreateSemaphore();
-        var results = await Task.WhenAll(nodes.Select(async item =>
+        var results = await RunParallelAsync(nodes, async item =>
         {
-            await sem.WaitAsync();
-            try
-            {
-                ReportGlobal($"Replication: {item.Node}");
-                return (item.Node,
-                        rows: (await client.Nodes[item.Node].Replication.GetAsync())
-                            .Select(a => new
-                            {
-                                item.Node,
-                                a.Id,
-                                a.Type,
-                                a.VmType,
-                                VmId = a.Guest,
-                                GuestName = long.TryParse(a.Guest, out var guestId)
-                                                && _resourcesByVmId.TryGetValue(guestId, out var guestRes)
-                                            ? guestRes.Name ?? ""
-                                            : "",
-                                a.Source,
-                                a.Target,
-                                a.Schedule,
-                                a.Disable,
-                                a.FailCount,
-                                a.Error,
-                                a.Duration,
-                                a.Rate,
-                                LastSync = FromUnixTime(a.LastSync),
-                                NextSync = FromUnixTime(a.NextSync),
-                                LastTry = FromUnixTime(a.LastTry),
-                                a.JobNum,
-                                CommentWrap = a.Comment,
-                            }).ToList());
-            }
-            finally { sem.Release(); }
-        }));
+            ReportGlobal($"Replication: {item.Node}");
+            return (item.Node,
+                    rows: (await client.Nodes[item.Node].Replication.GetAsync())
+                        .Select(a => new
+                        {
+                            item.Node,
+                            a.Id,
+                            a.Type,
+                            a.VmType,
+                            VmId = a.Guest,
+                            GuestName = long.TryParse(a.Guest, out var guestId)
+                                            && _resourcesByVmId.TryGetValue(guestId, out var guestRes)
+                                        ? guestRes.Name ?? ""
+                                        : "",
+                            a.Source,
+                            a.Target,
+                            a.Schedule,
+                            a.Disable,
+                            a.FailCount,
+                            a.Error,
+                            a.Duration,
+                            a.Rate,
+                            LastSync = FromUnixTime(a.LastSync),
+                            NextSync = FromUnixTime(a.NextSync),
+                            LastTry = FromUnixTime(a.LastTry),
+                            a.JobNum,
+                            CommentWrap = a.Comment,
+                        }).ToList());
+        });
 
         var sw = CreateSheetWriter(workbook, "Replication");
         sw.CreateTable(null,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdGuest.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdGuest.cs
@@ -21,54 +21,41 @@ public partial class ReportEngine
 
         if (guests.Count == 0) { return 0; }
 
-        var semaphore = CreateSemaphore();
-
-        var tasks = guests.Select(async item =>
+        var results = await RunParallelAsync(guests, async item =>
         {
-            await semaphore.WaitAsync();
-            try
-            {
-                ReportGlobal($"RRD Guest: {item.VmId} {item.Name}");
-
-                return (item,
-                        rows: (await client.GetVmRrdDataAsync(item.Node,
-                                                             item.VmType,
-                                                             item.VmId,
-                                                             settings.Guest.RrdData.TimeFrame,
-                                                             settings.Guest.RrdData.Consolidation))
-                                .Select(a => new
-                                {
-                                    item.Node,
-                                    Type = item.VmType.ToString(),
-                                    item.VmId,
-                                    item.Name,
-                                    a.TimeDate,
-                                    CpuUsagePct = a.CpuUsagePercentage,
-                                    MemorySizeGB = ToGB(a.MemorySize),
-                                    MemoryUsageGB = ToGB(a.MemoryUsage),
-                                    MemoryUsagePct = a.MemoryUsagePercentage,
-                                    NetInMB = ToMB(a.NetIn),
-                                    NetOutMB = ToMB(a.NetOut),
-                                    DiskReadMB = ToMB(a.DiskRead),
-                                    DiskWriteMB = ToMB(a.DiskWrite),
-                                    DiskSizeGB = ToGB(a.DiskSize),
-                                    DiskUsageGB = ToGB(a.DiskUsage),
-                                    DiskUsagePct = a.DiskUsagePercentage,
-                                    PsiCpuSomePct = a.PressureCpuSome,
-                                    PsiCpuFullPct = a.PressureCpuFull,
-                                    PsiIoSomePct = a.PressureIoSome,
-                                    PsiIoFullPct = a.PressureIoFull,
-                                    PsiMemSomePct = a.PressureMemorySome,
-                                    PsiMemFullPct = a.PressureMemoryFull,
-                                }).ToList());
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            ReportGlobal($"RRD Guest: {item.VmId} {item.Name}");
+            return (item,
+                    rows: (await client.GetVmRrdDataAsync(item.Node,
+                                                         item.VmType,
+                                                         item.VmId,
+                                                         settings.Guest.RrdData.TimeFrame,
+                                                         settings.Guest.RrdData.Consolidation))
+                            .Select(a => new
+                            {
+                                item.Node,
+                                Type = item.VmType.ToString(),
+                                item.VmId,
+                                item.Name,
+                                a.TimeDate,
+                                CpuUsagePct = a.CpuUsagePercentage,
+                                MemorySizeGB = ToGB(a.MemorySize),
+                                MemoryUsageGB = ToGB(a.MemoryUsage),
+                                MemoryUsagePct = a.MemoryUsagePercentage,
+                                NetInMB = ToMB(a.NetIn),
+                                NetOutMB = ToMB(a.NetOut),
+                                DiskReadMB = ToMB(a.DiskRead),
+                                DiskWriteMB = ToMB(a.DiskWrite),
+                                DiskSizeGB = ToGB(a.DiskSize),
+                                DiskUsageGB = ToGB(a.DiskUsage),
+                                DiskUsagePct = a.DiskUsagePercentage,
+                                PsiCpuSomePct = a.PressureCpuSome,
+                                PsiCpuFullPct = a.PressureCpuFull,
+                                PsiIoSomePct = a.PressureIoSome,
+                                PsiIoFullPct = a.PressureIoFull,
+                                PsiMemSomePct = a.PressureMemorySome,
+                                PsiMemFullPct = a.PressureMemoryFull,
+                            }).ToList());
         });
-
-        var results = await Task.WhenAll(tasks);
 
         var sw = CreateSheetWriter(workbook, "RRD Guests");
         sw.CreateTable(null,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdNode.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdNode.cs
@@ -25,46 +25,35 @@ public partial class ReportEngine
 
         var rrdTimeFrame = settings.Node.RrdData.TimeFrame.GetValue();
         var rrdConsolidation = settings.Node.RrdData.Consolidation.GetValue();
-        var semaphore = CreateSemaphore();
 
-        var tasks = nodes.Select(async item =>
+        var results = await RunParallelAsync(nodes, async item =>
         {
-            await semaphore.WaitAsync();
-            try
-            {
-                ReportGlobal($"RRD Nodes: {item.Node}");
-                return (item,
-                        rows: (await client.Nodes[item.Node].Rrddata.GetAsync(rrdTimeFrame, rrdConsolidation))
-                                .Select(a => new
-                                {
-                                    item.Node,
-                                    a.TimeDate,
-                                    CpuUsagePct = a.CpuUsagePercentage,
-                                    a.IoWait,
-                                    a.Loadavg,
-                                    MemorySizeGB = ToGB(a.MemorySize),
-                                    MemoryUsageGB = ToGB(a.MemoryUsage),
-                                    MemoryUsagePct = a.MemoryUsagePercentage,
-                                    SwapSizeGB = ToGB(a.SwapSize),
-                                    SwapUsageGB = ToGB(a.SwapUsage),
-                                    RootSizeGB = ToGB(a.RootSize),
-                                    RootUsageGB = ToGB(a.RootUsage),
-                                    NetInMB = ToMB(a.NetIn),
-                                    NetOutMB = ToMB(a.NetOut),
-                                    PsiCpuSomePct = a.PressureCpuSome,
-                                    PsiIoSomePct = a.PressureIoSome,
-                                    PsiIoFullPct = a.PressureIoFull,
-                                    PsiMemSomePct = a.PressureMemorySome,
-                                    PsiMemFullPct = a.PressureMemoryFull,
-                                }).ToList());
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            ReportGlobal($"RRD Nodes: {item.Node}");
+            return (item,
+                    rows: (await client.Nodes[item.Node].Rrddata.GetAsync(rrdTimeFrame, rrdConsolidation))
+                            .Select(a => new
+                            {
+                                item.Node,
+                                a.TimeDate,
+                                CpuUsagePct = a.CpuUsagePercentage,
+                                a.IoWait,
+                                a.Loadavg,
+                                MemorySizeGB = ToGB(a.MemorySize),
+                                MemoryUsageGB = ToGB(a.MemoryUsage),
+                                MemoryUsagePct = a.MemoryUsagePercentage,
+                                SwapSizeGB = ToGB(a.SwapSize),
+                                SwapUsageGB = ToGB(a.SwapUsage),
+                                RootSizeGB = ToGB(a.RootSize),
+                                RootUsageGB = ToGB(a.RootUsage),
+                                NetInMB = ToMB(a.NetIn),
+                                NetOutMB = ToMB(a.NetOut),
+                                PsiCpuSomePct = a.PressureCpuSome,
+                                PsiIoSomePct = a.PressureIoSome,
+                                PsiIoFullPct = a.PressureIoFull,
+                                PsiMemSomePct = a.PressureMemorySome,
+                                PsiMemFullPct = a.PressureMemoryFull,
+                            }).ToList());
         });
-
-        var results = await Task.WhenAll(tasks);
 
         var sw = CreateSheetWriter(workbook, "RRD Nodes");
         sw.CreateTable(null,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdStorage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdStorage.cs
@@ -20,34 +20,22 @@ public partial class ReportEngine
 
         var rrdTimeFrame = settings.Storage.RrdData.TimeFrame.GetValue();
         var rrdConsolidation = settings.Storage.RrdData.Consolidation.GetValue();
-        var semaphore = CreateSemaphore();
 
-        var tasks = filtered.Select(async item =>
+        var results = await RunParallelAsync(filtered, async item =>
         {
-            await semaphore.WaitAsync();
-            try
-            {
-                ReportGlobal($"RRD Storage: {item.Node} {item.Storage}");
-
-                return (item,
-                        rows: (await client.Nodes[item.Node].Storage[item.Storage].Rrddata.GetAsync(rrdTimeFrame, rrdConsolidation))
-                            .Select(a => new
-                            {
-                                Node = StorageNode(item),
-                                item.Storage,
-                                a.TimeDate,
-                                SizeGB = ToGB(a.Size),
-                                UsedGB = ToGB(a.Used),
-                                UsagePct = a.Size > 0 ? (double)a.Used / a.Size : (double?)null,
-                            }).ToList());
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            ReportGlobal($"RRD Storage: {item.Node} {item.Storage}");
+            return (item,
+                    rows: (await client.Nodes[item.Node].Storage[item.Storage].Rrddata.GetAsync(rrdTimeFrame, rrdConsolidation))
+                        .Select(a => new
+                        {
+                            Node = StorageNode(item),
+                            item.Storage,
+                            a.TimeDate,
+                            SizeGB = ToGB(a.Size),
+                            UsedGB = ToGB(a.Used),
+                            UsagePct = a.Size > 0 ? (double)a.Used / a.Size : (double?)null,
+                        }).ToList());
         });
-
-        var results = await Task.WhenAll(tasks);
 
         var sw = CreateSheetWriter(workbook, "RRD Storage");
         sw.CreateTable(null,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Snapshots.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Snapshots.cs
@@ -22,47 +22,35 @@ public partial class ReportEngine
 
         if (resources.Count == 0) { return 0; }
 
-        var sw = CreateSheetWriter(workbook, "Snapshots");
-        var semaphore = CreateSemaphore();
-
-        var tasks = resources.Select(async item =>
+        var results = await RunParallelAsync(resources, async item =>
         {
-            await semaphore.WaitAsync();
-            try
-            {
-                ReportGlobal($"Snapshots: {item.Node} {item.VmId}");
+            ReportGlobal($"Snapshots: {item.Node} {item.VmId}");
 
-                var rows = new List<dynamic>();
-                foreach (var snapshot in await SnapshotHelper.GetSnapshotsAsync(client, item.Node, item.VmType, item.VmId))
+            var rows = new List<dynamic>();
+            foreach (var snapshot in await SnapshotHelper.GetSnapshotsAsync(client, item.Node, item.VmType, item.VmId))
+            {
+                rows.Add(new
                 {
-                    rows.Add(new
-                    {
-                        item.Node,
-                        item.VmId,
-                        VmName = item.Name,
-                        item.VmType,
-                        Snapshot = snapshot.Name,
-                        snapshot.Parent,
-                        snapshot.Date,
-                        IncludeRamFlag = ToX(snapshot.VmStatus),
+                    item.Node,
+                    item.VmId,
+                    VmName = item.Name,
+                    item.VmType,
+                    Snapshot = snapshot.Name,
+                    snapshot.Parent,
+                    snapshot.Date,
+                    IncludeRamFlag = ToX(snapshot.VmStatus),
 
-                        SizeGB = SnapshotSizeProvider != null
-                                    ? ToGB(await SnapshotSizeProvider(item.Node, item.VmType, item.VmId, snapshot.Name))
-                                    : (double?)null,
+                    SizeGB = SnapshotSizeProvider != null
+                                ? ToGB(await SnapshotSizeProvider(item.Node, item.VmType, item.VmId, snapshot.Name))
+                                : (double?)null,
 
-                        DescriptionWrap = snapshot.Description,
-                    });
-                }
-                return (item, rows);
+                    DescriptionWrap = snapshot.Description,
+                });
             }
-            finally
-            {
-                semaphore.Release();
-            }
+            return (item, rows);
         });
 
-        var results = await Task.WhenAll(tasks);
-
+        var sw = CreateSheetWriter(workbook, "Snapshots");
         sw.CreateTable(null,
                        results.OrderBy(r => r.item.Id).SelectMany(r => r.rows).ToList(),
                        tbl =>

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.StorageContent.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.StorageContent.cs
@@ -32,70 +32,57 @@ public partial class ReportEngine
                 ? res.Name ?? ""
                 : "";
 
-        var semaphore = CreateSemaphore();
-
-        var tasks = filtered.Select(async item =>
+        var results = await RunParallelAsync(filtered, async item =>
         {
-            await semaphore.WaitAsync();
-            try
-            {
-                ReportGlobal($"Storage Content: {item.Node} {item.Storage}");
+            ReportGlobal($"Storage Content: {item.Node} {item.Storage}");
 
-                var allContent = await client.Nodes[item.Node].Storage[item.Storage].Content.GetAsync();
+            var allContent = await client.Nodes[item.Node].Storage[item.Storage].Content.GetAsync();
+            var storageSize = item.DiskSize;
 
-                var storageSize = item.DiskSize;
+            var contentRows = settings.Storage.IncludeContentSheet
+                                ? allContent.Where(a => !string.Equals(a.Content, "backup", StringComparison.OrdinalIgnoreCase))
+                                           .Select(a => new
+                                           {
+                                               Node = StorageNode(item),
+                                               item.Storage,
+                                               a.Content,
+                                               a.FileName,
+                                               a.Format,
+                                               SizeGB = ToGB(a.Size),
+                                               StorageUsagePct = StorageUsagePct(a.Size, storageSize),
+                                               VmId = FormatVmId(a.VmId),
+                                               GuestName = GuestName(a.VmId),
+                                               a.CreationDate,
+                                               NotesWrap = a.Notes,
+                                               a.Parent,
+                                           })
+                                           .ToList()
+                                : [];
 
-                var contentRows = settings.Storage.IncludeContentSheet
-                                    ? allContent.Where(a => !string.Equals(a.Content, "backup", StringComparison.OrdinalIgnoreCase))
-                                               .Select(a => new
-                                               {
-                                                   Node = StorageNode(item),
-                                                   item.Storage,
-                                                   a.Content,
-                                                   a.FileName,
-                                                   a.Format,
-                                                   SizeGB = ToGB(a.Size),
-                                                   StorageUsagePct = StorageUsagePct(a.Size, storageSize),
-                                                   VmId = FormatVmId(a.VmId),
-                                                   GuestName = GuestName(a.VmId),
-                                                   a.CreationDate,
-                                                   NotesWrap = a.Notes,
-                                                   a.Parent,
-                                               })
-                                               .ToList()
-                                    : [];
+            var backupRows = settings.Storage.IncludeBackupsSheet
+                                ? allContent.Where(a => string.Equals(a.Content, "backup", StringComparison.OrdinalIgnoreCase))
+                                           .Select(a => new
+                                           {
+                                               Node = StorageNode(item),
+                                               item.Storage,
+                                               a.FileName,
+                                               a.Format,
+                                               SizeGB = ToGB(a.Size),
+                                               StorageUsagePct = StorageUsagePct(a.Size, storageSize),
+                                               VmId = FormatVmId(a.VmId),
+                                               GuestName = GuestName(a.VmId),
+                                               a.CreationDate,
+                                               NotesWrap = a.Notes,
+                                               ProtectedFlag = ToX(a.Protected),
+                                               EncryptedFlag = ToX(a.Encrypted),
+                                               VerifiedFlag = ToX(a.Verified),
+                                               a.Parent,
+                                           })
+                                           .ToList()
+                                : [];
 
-                var backupRows = settings.Storage.IncludeBackupsSheet
-                                    ? allContent.Where(a => string.Equals(a.Content, "backup", StringComparison.OrdinalIgnoreCase))
-                                               .Select(a => new
-                                               {
-                                                   Node = StorageNode(item),
-                                                   item.Storage,
-                                                   a.FileName,
-                                                   a.Format,
-                                                   SizeGB = ToGB(a.Size),
-                                                   StorageUsagePct = StorageUsagePct(a.Size, storageSize),
-                                                   VmId = FormatVmId(a.VmId),
-                                                   GuestName = GuestName(a.VmId),
-                                                   a.CreationDate,
-                                                   NotesWrap = a.Notes,
-                                                   ProtectedFlag = ToX(a.Protected),
-                                                   EncryptedFlag = ToX(a.Encrypted),
-                                                   VerifiedFlag = ToX(a.Verified),
-                                                   a.Parent,
-                                               })
-                                               .ToList()
-                                    : [];
-
-                return (item, contentRows, backupRows);
-            }
-            finally
-            {
-                semaphore.Release();
-            }
+            return (item, contentRows, backupRows);
         });
-
-        var results = await Task.WhenAll(tasks);
         var ordered = results.OrderBy(r => r.item.Id).ToList();
 
         if (settings.Storage.IncludeContentSheet)

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
@@ -23,7 +23,7 @@ public partial class ReportEngine
         public string AgentVersion { get; init; } = "";
         public VmQemuAgentOsInfo? AgentOsInfo { get; init; }
         public List<VmNetworkRow> Networks { get; init; } = [];
-        public IEnumerable<VmQemuAgentGetFsInfo.ResultInt> FsInfo { get; init; } = [];
+        public IEnumerable<VmQemuAgentGetFsInfo.ResultInfo> FsInfo { get; init; } = [];
     }
 
     private async Task<VmFetchData> FetchVmDataAsync(ClusterResource item, ProgressTracker pt)
@@ -41,7 +41,7 @@ public partial class ReportEngine
         var agentRunning = false;
         var agentVersion = "";
         var networks = new List<VmNetworkRow>();
-        IEnumerable<VmQemuAgentGetFsInfo.ResultInt> fsInfo = [];
+        IEnumerable<VmQemuAgentGetFsInfo.ResultInfo> fsInfo = [];
 
         if (!item.IsUnknown && item.IsRunning)
         {
@@ -168,14 +168,8 @@ public partial class ReportEngine
         var items = new List<dynamic>();
         var pt = new ProgressTracker(_progress, resources.Count);
 
-        var semaphore = CreateSemaphore();
-        var tasks = resources.Select(async item =>
-        {
-            await semaphore.WaitAsync();
-            try { return await FetchVmDataAsync(item, pt); }
-            finally { semaphore.Release(); }
-        });
-        var results = (await Task.WhenAll(tasks)).OrderBy(d => d.Item.Id).ToList();
+        var results = (await RunParallelAsync(resources, item => FetchVmDataAsync(item, pt)))
+                            .OrderBy(d => d.Item.Id).ToList();
 
         foreach (var d in results)
         {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
 using ClosedXML.Excel;
 using Corsinvest.ProxmoxVE.Api;
 using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
-using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Text.RegularExpressions;
 
 namespace Corsinvest.ProxmoxVE.Report;
 
@@ -29,7 +29,7 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
     private readonly List<VmNetworkRow> _pendingNetworkRows = [];
     private readonly List<(string Node, NodeNetwork Network)> _pendingNodeNetworkRows = [];
     private readonly List<(ClusterResource Vm, IEnumerable<VmDisk> Disks)> _pendingDiskRows = [];
-    private readonly List<(ClusterResource Vm, IEnumerable<VmQemuAgentGetFsInfo.ResultInt> Partitions)> _pendingPartitionRows = [];
+    private readonly List<(ClusterResource Vm, IEnumerable<VmQemuAgentGetFsInfo.ResultInfo> Partitions)> _pendingPartitionRows = [];
     private HashSet<long> _vmIds = [];
     private readonly Dictionary<string, int> _usedSheetNames = [];
 
@@ -130,9 +130,17 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
     public async Task<Stream> GenerateAsync(IProgress<ReportProgress>? progress = null)
     {
         _progress = progress;
+        var originalTimeout = client.Timeout;
         if (settings.ApiTimeout > 0) { client.Timeout = TimeSpan.FromSeconds(settings.ApiTimeout); }
         var stream = new MemoryStream();
-        await GenerateExcelAsync(stream);
+        try
+        {
+            await GenerateExcelAsync(stream);
+        }
+        finally
+        {
+            client.Timeout = originalTimeout;
+        }
         stream.Position = 0;
         return stream;
     }
@@ -258,7 +266,16 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
     private static double ToGB(double bytes) => Math.Round(bytes / 1024 / 1024 / 1024, 2);
     private static double ToMB(double bytes) => Math.Round(bytes / 1024 / 1024, 2);
 
-    private SemaphoreSlim CreateSemaphore() => new(settings.MaxParallelRequests);
+    private async Task<TResult[]> RunParallelAsync<T, TResult>(IEnumerable<T> source, Func<T, Task<TResult>> func)
+    {
+        var semaphore = new SemaphoreSlim(settings.MaxParallelRequests);
+        return await Task.WhenAll(source.Select(async item =>
+        {
+            await semaphore.WaitAsync();
+            try { return await func(item); }
+            finally { semaphore.Release(); }
+        }));
+    }
 
     private static string ToX(bool value)
         => value

--- a/src/Corsinvest.ProxmoxVE.Report/SettingsNodeDetail.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/SettingsNodeDetail.cs
@@ -34,4 +34,5 @@ public class SettingsNodeDetail
     /// Include firewall log sheet
     /// </summary>
     public bool IncludeFirewallLog { get; set; } = true;
+
 }


### PR DESCRIPTION
## Summary

- Add `/etc/hosts` table to each node detail sheet, placed after the Network table
- Offline nodes are now skipped gracefully — no more API errors when a node is down
- All manual `SemaphoreSlim` + `Task.WhenAll` patterns replaced by a shared `RunParallelAsync` helper
- `AppendRules` in firewall now uses `CreateOrAddTable` like `AppendAliases`/`AppendIpSets`
- API packages bumped to 9.1.13
- Version bumped to 1.7.0

## Test plan

- [ ] Generate report on a cluster with all nodes online — `/etc/hosts` table appears in each node detail sheet after Network
- [ ] Generate report with one node offline — report completes without errors, offline node appears in Nodes sheet with no detail sheet
- [ ] Verify Firewall sheet still generates correctly with rules/aliases/ipsets