### PR TITLE
fix: handle 501 Not Implemented for /cluster/mapping/dir on older PVE

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Report/PveResultExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/PveResultExtensions.cs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Net;
+using Corsinvest.ProxmoxVE.Api;
+
+namespace Corsinvest.ProxmoxVE.Report;
+
+internal static class PveResultExtensions
+{
+    /// <summary>
+    /// Maps a PVE API result to a typed enumerable, returning an empty sequence when the
+    /// endpoint is not implemented on the target Proxmox version (HTTP 501).
+    /// Use for endpoints introduced in newer PVE releases that older clusters lack.
+    /// </summary>
+    public static async Task<IEnumerable<T>> ToModelEnumerableSafeAsync<T>(this Task<Result> resultTask)
+    {
+        var r = await resultTask;
+        return r.StatusCode == HttpStatusCode.NotImplemented
+            ? []
+            : r.ToModel<IEnumerable<T>>();
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
@@ -84,7 +84,10 @@ public partial class ReportEngine
         var vnetsTask = client.Cluster.Sdn.Vnets.GetAsync();
         var sdnControllersTask = client.Cluster.Sdn.Controllers.GetAsync();
         var sdnIpamsTask = client.Cluster.Sdn.Ipams.GetAsync();
-        var mappingDirTask = client.Cluster.Mapping.Dir.GetAsync();
+
+        var mappingDirTask = client.Cluster.Mapping.Dir.Index()
+                                                       .ToModelEnumerableSafeAsync<Api.Shared.Models.Cluster.ClusterMappingDir>();
+
         var mappingPciTask = client.Cluster.Mapping.Pci.GetAsync();
         var mappingUsbTask = client.Cluster.Mapping.Usb.GetAsync();
         var poolsTask = client.Pools.GetAsync();
@@ -116,15 +119,15 @@ public partial class ReportEngine
         ReportGlobal("Cluster: Options");
         sw.CreateTable("Options",
                        [new
-                           {
-                               optionsTask.Result.Console,
-                               optionsTask.Result.Keyboard,
-                               optionsTask.Result.MacPrefix,
-                               DescriptionWrap = optionsTask.Result.Description,
-                               AllowedTags = ToNewLine(string.Join(",", optionsTask.Result.AllowedTags ?? [])),
-                               MigrationType = optionsTask.Result.Migration?.Type,
-                               MigrationNetwork = optionsTask.Result.Migration?.Network,
-                           }]);
+                        {
+                            optionsTask.Result.Console,
+                            optionsTask.Result.Keyboard,
+                            optionsTask.Result.MacPrefix,
+                            DescriptionWrap = optionsTask.Result.Description,
+                            AllowedTags = ToNewLine(string.Join(",", optionsTask.Result.AllowedTags ?? [])),
+                            MigrationType = optionsTask.Result.Migration?.Type,
+                            MigrationNetwork = optionsTask.Result.Migration?.Network,
+                        }]);
 
         ReportGlobal("Cluster: Security");
         sw.CreateTable("Users",


### PR DESCRIPTION
## Summary
- Older Proxmox VE clusters (e.g. 8.3.5) don't implement `/cluster/mapping/dir` and return `501 Not Implemented`, which crashed report generation.
- Added an internal `ToModelEnumerableSafeAsync<T>` extension that returns an empty sequence on 501, and used it for the mapping/dir fetch.
- The Mapping Dir sheet is simply empty when the endpoint isn't available; the rest of the report is unaffected.

Closes #20.

## Test plan
- [ ] Run `cv4pve-report export` against a PVE 8.3.x cluster and verify the report generates successfully.
- [ ] Run against a recent PVE cluster that supports `/cluster/mapping/dir` and verify the Mapping Dir sheet still gets populated.