### PR TITLE
chore: release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.8.1] — 2026-05-04
+
+### Fixes
+
+- **Compatibility with older PVE clusters** — the `/cluster/mapping/dir` endpoint was added in newer Proxmox VE releases; older clusters (e.g. 8.3.x) returned `501 Not Implemented` and crashed the report. The fetch now degrades gracefully: the **Mapping Dir** sheet is simply empty when the endpoint isn't available, and the rest of the report is unaffected. Thanks @janrenard for the report (#20).
+
+---
+
 ## [1.8.0] — 2026-04-15
 
 ### What's new

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>1.8.0</Version>
+        <Version>1.8.1</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- Bump version to 1.8.1
- Add CHANGELOG entry for 1.8.1 covering the fix for `/cluster/mapping/dir` 501 on older PVE clusters (closes #20, merged via #22)

## Test plan
- [ ] Verify CI passes on this branch
- [ ] After merge, tag `v1.8.1` and publish a GitHub release