### PR TITLE
fix: 2.0.1 — VM/CT detail crash on minimal configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [2.0.1] — 2026-05-08
+
+### Fixes
+
+- **Reports no longer crash on VM/CT detail pages** — a leftover code path in v2.0.0 still failed when a VM or container had a minimal config without extra fields. The detail page now renders cleanly in those cases. Thanks again @janrenard for spotting it (#24).
+
+---
+
 ## [2.0.0] — 2026-05-08
 
 ### What's new

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
@@ -191,9 +191,12 @@ public partial class ReportEngine
             ["Hookscript"] = config.Hookscript,
         };
 
-        foreach (var (key, value) in config.ExtensionData.OrderBy(a => a.Key))
+        if (config.ExtensionData != null)
         {
-            configKv.TryAdd(key, value);
+            foreach (var (key, value) in config.ExtensionData.OrderBy(a => a.Key))
+            {
+                configKv.TryAdd(key, value);
+            }
         }
 
         sw.AddKeyValueRow(($"{d.Item.VmId} - {d.Item.Name}", mainKv), ("Config", configKv));

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
@@ -331,9 +331,12 @@ public partial class ReportEngine
             ["Hookscript"] = config.Hookscript,
         };
 
-        foreach (var (key, value) in config.ExtensionData.OrderBy(a => a.Key))
+        if (config.ExtensionData != null)
         {
-            configKv.TryAdd(key, value);
+            foreach (var (key, value) in config.ExtensionData.OrderBy(a => a.Key))
+            {
+                configKv.TryAdd(key, value);
+            }
         }
 
         pt.Step("QemuAgent");


### PR DESCRIPTION
## Summary

Hotfix for v2.0.0: a leftover code path in the VM/CT detail rendering still accessed `config.ExtensionData` directly. On VMs whose JSON deserialiser populated `ExtensionData` as null (minimal configs with nothing beyond the strongly-typed properties), `OrderBy` then threw `Value cannot be null. (Parameter 'source')` and aborted the whole report.

The detail page now skips the extra-keys block cleanly when there are none.

Reproduces consistently on @janrenard's cluster (#24, second occurrence after v2.0.0).

Closes #24

## Test plan

- [ ] `dotnet build` clean (verified locally — 0 warnings, 0 errors)
- [ ] Generate report on @janrenard's cluster — reaches the end successfully
- [ ] Spot-check a few VM/CT detail pages render correctly