### PR TITLE
feat: resilient collection + Issues page (fixes #33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ---
 
+## [2.2.0] — 2026-05-11
+
+### What's new
+
+- **Resilient collection — broken endpoints no longer abort the report.** A single failing Proxmox API call (a storage with a corrupt RRD file, a node returning `500`, missing permissions on a sub-resource) used to terminate the whole report. Failures are now collected into a dedicated **Issues** page that lists every problem with severity, section, the full Proxmox error message and the API endpoint that returned it. `501 Not Implemented` (endpoint missing in older PVE versions) stays silent — everything else surfaces as a `Warning` you can act on. Thanks @janrenard for the report (#33).
+- **Issues page — second tab after Summary / second link after Home.** The Issues page only appears when there is something to report: a dedicated sheet in Excel positioned right after `Summary`, and the second sidebar link after `Home` in HTML. Issue rows are hyperlinked back to the relevant detail page (the failing VM, node, storage, or the global section) so you can jump straight to the context where the failure happened.
+- **Cover/Summary now shows a Description column.** Both formats list every section in the Contents table with a one-line description of what's inside — consistent between Excel and HTML. Issue counts and per-section durations are unchanged.
+
+---
+
 ## [2.1.0] — 2026-05-10
 
 ### Breaking changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>2.1.0</Version>
+        <Version>2.2.0</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Report Tool for Proxmox VE (Made in Italy)
 
 **Network Diagram** — each export also produces an SVG showing the full network topology per node (physical NICs → bonds → bridges → gateway VMs → internal bridges → leaf VMs) plus a dedicated strip for network-backed storage. Open it in any browser — see the [guide](docs/network-diagram.md) and [sample](docs/network-diagram.svg).
 
+**Resilient by design** — a single broken endpoint (a storage with a corrupt RRD file, a node returning 500, missing permissions on a sub-resource) no longer aborts the report. Failed calls are collected into a dedicated **Issues** page that lists severity, section, the full Proxmox error message and the API endpoint that failed — each row is hyperlinked to the relevant detail page (VM, node, cluster, …). 501 *Not Implemented* on endpoints missing in older PVE versions is silent, everything else surfaces as a `Warning` you can act on. The Issues page only appears when there is something to report.
+
 <p align="center">
   <a href="docs/network-diagram.svg"><img src="docs/network-diagram.png" alt="Network Diagram preview" width="75%"></a>
 </p>
@@ -68,6 +70,7 @@ RVTools is a pure inventory tool for VMware — it exports infrastructure data t
 | APT packages / updates | | ✓ | |
 | Syslog (all nodes, parsed into columns) | | ✓ | |
 | Cluster log & cluster tasks | | ✓ | |
+| Resilient collection (skip & report broken endpoints) | | ✓ | |
 | Health checks & diagnostics | | | ✓ |
 
 > **cv4pve-report** shows you *what* is in your infrastructure.
@@ -237,6 +240,7 @@ What's collected:
 - **Nodes** — services, network, disks, SMART, ZFS, APT, SSL certificates, replication, syslog, firewall logs, tasks
 - **VMs/CTs** — config, network, disks, snapshots, firewall logs, tasks, QEMU agent info
 - **Global sections** — Firewall (rules/aliases/ipsets), RRD Nodes/Storage/Guests, Syslog, Cluster Log, Cluster Tasks, Replication, Network, Disks, Partitions, Snapshots, Storage Content, Backups
+- **Issues** — diagnostic page that aggregates any per-resource failure encountered while collecting data; appears only when there is at least one issue and is linked from the Summary/cover and the sidebar so it's the first thing you see when something didn't work
 - **Network topology** — auto-generated SVG diagram of physical NICs, bonds, bridges, gateway VMs and network-backed storage — [guide](docs/network-diagram.md)
 
 How you can shape it:

--- a/src/Corsinvest.ProxmoxVE.Report/Issue.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Issue.cs
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report;
+
+internal enum IssueSeverity { Info, Warning, Error }
+
+internal sealed record Issue(
+    IssueSeverity Severity,
+    string Section,
+    string Message,
+    DateTime Timestamp,
+    string LinkKey);

--- a/src/Corsinvest.ProxmoxVE.Report/IssueTracker.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/IssueTracker.cs
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report;
+
+internal sealed class IssueTracker
+{
+    private readonly List<Issue> _issues = [];
+
+    public IReadOnlyList<Issue> All => _issues;
+    public bool HasAny => _issues.Count > 0;
+
+    public void Add(IssueSeverity severity, string section, string message, string linkKey)
+        => _issues.Add(new Issue(severity, section, message, DateTime.Now, linkKey));
+
+    public void Info(string section, string message, string linkKey) => Add(IssueSeverity.Info, section, message, linkKey);
+    public void Warning(string section, string message, string linkKey) => Add(IssueSeverity.Warning, section, message, linkKey);
+    public void Error(string section, string message, string linkKey) => Add(IssueSeverity.Error, section, message, linkKey);
+}

--- a/src/Corsinvest.ProxmoxVE.Report/PveResultExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/PveResultExtensions.cs
@@ -10,11 +10,79 @@ namespace Corsinvest.ProxmoxVE.Report;
 
 internal static class PveResultExtensions
 {
-    public static async Task<IEnumerable<T>> ToModelEnumerableSafeAsync<T>(this Task<Result> resultTask)
+    /// <summary>
+    /// Awaits an SDK extension call returning IEnumerable&lt;T&gt;. Maps HTTP errors
+    /// (via PveResultException) to Issues and returns an empty list on failure.
+    /// </summary>
+    public static async Task<IReadOnlyList<T>> ToSafeEnum<T>(this Task<IEnumerable<T>> task,
+                                                             IssueTracker issues,
+                                                             string section,
+                                                             string linkKey)
     {
-        var r = await resultTask;
-        return r.StatusCode == HttpStatusCode.NotImplemented
-            ? []
-            : r.ToModel<IEnumerable<T>>();
+        try { return (await task)?.ToList() ?? []; }
+        catch (PveResultException pex) { Record(issues, section, linkKey, pex); return []; }
+        catch (Exception ex) when (ex is not OperationCanceledException) { issues.Warning(section, ex.Message, linkKey); return []; }
     }
+
+    /// <summary>
+    /// Single-object variant of <see cref="ToSafeEnum{T}"/>. Returns <c>default(T)</c> on failure.
+    /// </summary>
+    public static async Task<T?> ToSafeSingle<T>(this Task<T> task,
+                                                 IssueTracker issues,
+                                                 string section,
+                                                 string linkKey)
+    {
+        try { return await task; }
+        catch (PveResultException pex) { Record(issues, section, linkKey, pex); return default; }
+        catch (Exception ex) when (ex is not OperationCanceledException) { issues.Warning(section, ex.Message, linkKey); return default; }
+    }
+
+    /// <summary>
+    /// Awaits a raw Proxmox API call returning text payload (e.g. /etc/hosts).
+    /// Records HTTP errors as Issues and returns empty string on failure.
+    /// </summary>
+    public static async Task<string> ToSafeText(this Task<Result> task,
+                                                IssueTracker issues,
+                                                string section,
+                                                string linkKey)
+    {
+        try
+        {
+            var r = await task;
+            if (r.IsSuccessStatusCode) { return (string?)r.ToData()?.data ?? ""; }
+            var severity = ClassifyHttpStatus(r.StatusCode);
+            if (severity is { } s) { issues.Add(s, section, BuildMessage(r), linkKey); }
+            return "";
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException) { issues.Warning(section, ex.Message, linkKey); return ""; }
+    }
+
+    private static void Record(IssueTracker issues, string section, string linkKey, PveResultException pex)
+    {
+        var severity = ClassifyHttpStatus(pex.Result.StatusCode);
+        if (severity is { } s) { issues.Add(s, section, BuildMessage(pex.Result), linkKey); }
+    }
+
+    /// <summary>
+    /// Builds a diagnostic message from a Result: "&lt;code&gt; &lt;reason&gt; — &lt;api error&gt; — &lt;METHOD&gt; &lt;path&gt;".
+    /// The body error and request path are included when available so the Issues page is self-contained.
+    /// </summary>
+    private static string BuildMessage(Result r)
+    {
+        var parts = new List<string> { $"{(int)r.StatusCode} {r.ReasonPhrase}" };
+        var apiError = r.GetError();
+        if (!string.IsNullOrWhiteSpace(apiError)) { parts.Add(apiError); }
+        if (!string.IsNullOrWhiteSpace(r.RequestResource)) { parts.Add($"{r.MethodType} {r.RequestResource}"); }
+        return string.Join(" — ", parts);
+    }
+
+    // 501 is silent — the endpoint doesn't exist on this PVE version, not an issue.
+    // Everything else (403, 404, 5xx, network errors) is surfaced as a Warning so the
+    // user can act on it.
+    private static IssueSeverity? ClassifyHttpStatus(HttpStatusCode status)
+        => status switch
+        {
+            HttpStatusCode.NotImplemented => null,
+            _ => IssueSeverity.Warning,
+        };
 }

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
@@ -4,6 +4,7 @@
  */
 
 using Corsinvest.ProxmoxVE.Api.Extension;
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Api.Shared.Utils;
 using Corsinvest.ProxmoxVE.Report.Writers;
 
@@ -53,62 +54,55 @@ public partial class ReportEngine
 
         ReportGlobal("Cluster: Fetching data");
 
-        var optionsTask = client.Cluster.Options.GetAsync();
-        var usersTask = client.Access.Users.GetAsync(full: true);
-        var tfaTask = client.Access.Tfa.GetAsync();
-        var groupsTask = client.Access.Groups.GetAsync();
-        var rolesTask = client.Access.Roles.GetAsync();
-        var aclTask = client.Access.Acl.GetAsync();
-        var domainsTask = client.Access.Domains.GetAsync();
-        var backupJobsTask = client.Cluster.Backup.GetAsync();
-        var replicationTask = client.Cluster.Replication.GetAsync();
-        var metricServersTask = client.Cluster.Metrics.Server.GetAsync();
-        var sdnZonesTask = client.Cluster.Sdn.Zones.GetAsync();
-        var vnetsTask = client.Cluster.Sdn.Vnets.GetAsync();
-        var sdnControllersTask = client.Cluster.Sdn.Controllers.GetAsync();
-        var sdnIpamsTask = client.Cluster.Sdn.Ipams.GetAsync();
-
-        var mappingDirTask = client.Cluster.Mapping.Dir.Index()
-                                                       .ToModelEnumerableSafeAsync<Api.Shared.Models.Cluster.ClusterMappingDir>();
-
-        var mappingPciTask = client.Cluster.Mapping.Pci.GetAsync();
-        var mappingUsbTask = client.Cluster.Mapping.Usb.GetAsync();
-        var poolsTask = client.Pools.GetAsync();
-        var haResourcesTask = client.Cluster.Ha.Resources.GetAsync();
-        var haStatusTask = client.Cluster.Ha.Status.Current.GetAsync();
+        var optionsTask = client.Cluster.Options.GetAsync().ToSafeSingle(_issues, "Cluster", LinkKey.Cluster);
+        var usersTask = client.Access.Users.GetAsync(full: true).ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var tfaTask = client.Access.Tfa.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var groupsTask = client.Access.Groups.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var rolesTask = client.Access.Roles.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var aclTask = client.Access.Acl.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var domainsTask = client.Access.Domains.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var backupJobsTask = client.Cluster.Backup.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var replicationTask = client.Cluster.Replication.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var metricServersTask = client.Cluster.Metrics.Server.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var sdnZonesTask = client.Cluster.Sdn.Zones.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var vnetsTask = client.Cluster.Sdn.Vnets.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var sdnControllersTask = client.Cluster.Sdn.Controllers.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var sdnIpamsTask = client.Cluster.Sdn.Ipams.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var mappingDirTask = client.Cluster.Mapping.Dir.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var mappingPciTask = client.Cluster.Mapping.Pci.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var mappingUsbTask = client.Cluster.Mapping.Usb.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var poolsTask = client.Pools.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var haResourcesTask = client.Cluster.Ha.Resources.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var haStatusTask = client.Cluster.Ha.Status.Current.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
 
         var fwOptionsTask = settings.Firewall.Enabled
-                                ? client.Cluster.Firewall.Options.GetAsync()
-                                : null;
+                                ? client.Cluster.Firewall.Options.GetAsync().ToSafeSingle(_issues, "Cluster", LinkKey.Cluster)
+                                : Task.FromResult<ClusterFirewallOptions?>(null);
 
         var haGroupsTask = haGroupsSupported
-                            ? client.Cluster.Ha.Groups.GetAsync()
-                            : null;
+                            ? client.Cluster.Ha.Groups.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster)
+                            : Task.FromResult<IReadOnlyList<ClusterHaGroup>>([]);
 
-        var waitTasks = new List<Task>
-        {
+        await Task.WhenAll(
             optionsTask, usersTask, tfaTask, groupsTask, rolesTask, aclTask, domainsTask,
             backupJobsTask, replicationTask, metricServersTask,
             sdnZonesTask, vnetsTask, sdnControllersTask, sdnIpamsTask,
             mappingDirTask, mappingPciTask, mappingUsbTask,
             poolsTask, haResourcesTask, haStatusTask,
-        };
-        if (fwOptionsTask != null) { waitTasks.Add(fwOptionsTask); }
-        if (haGroupsTask != null) { waitTasks.Add(haGroupsTask); }
-
-        await Task.WhenAll(waitTasks);
+            fwOptionsTask, haGroupsTask);
 
         ReportGlobal("Cluster: Options");
+        var options = optionsTask.Result ?? new ClusterOptions();
         sw.AddTable("Options",
                     [new
                     {
-                        optionsTask.Result.Console,
-                        optionsTask.Result.Keyboard,
-                        optionsTask.Result.MacPrefix,
-                        DescriptionWrap = optionsTask.Result.Description,
-                        AllowedTags = ToNewLine(string.Join(",", optionsTask.Result.AllowedTags ?? [])),
-                        MigrationType = optionsTask.Result.Migration?.Type,
-                        MigrationNetwork = optionsTask.Result.Migration?.Network,
+                        options.Console,
+                        options.Keyboard,
+                        options.MacPrefix,
+                        DescriptionWrap = options.Description,
+                        AllowedTags = ToNewLine(string.Join(",", options.AllowedTags ?? [])),
+                        MigrationType = options.Migration?.Type,
+                        MigrationNetwork = options.Migration?.Network,
                     }]);
 
         ReportGlobal("Cluster: Security");
@@ -129,7 +123,7 @@ public partial class ReportEngine
                     }));
 
         sw.AddTable("API Tokens",
-                    usersTask.Result.SelectMany(a => a.Tokens.Select(t => new
+                    usersTask.Result.SelectMany(a => (a.Tokens ?? []).Select(t => new
                     {
                         User = a.Id,
                         TokenId = t.Id,
@@ -181,10 +175,10 @@ public partial class ReportEngine
                         a.Comment
                     }));
 
-        if (settings.Firewall.Enabled && fwOptionsTask != null)
+        if (settings.Firewall.Enabled)
         {
             ReportGlobal("Cluster: Firewall Options");
-            var fwOptions = fwOptionsTask.Result;
+            var fwOptions = fwOptionsTask.Result ?? new ClusterFirewallOptions();
             sw.AddTable("Firewall Options",
                         [new
                         {
@@ -235,7 +229,7 @@ public partial class ReportEngine
                         a.JobNum,
                         a.RemoveJob,
                     }).ToList(),
-                    new TableOptions<dynamic>().WithReplicationLinks(nodeSelector: r => null,                  // Replication has no Node column
+                    new TableOptions<dynamic>().WithReplicationLinks(nodeSelector: _ => null,                  // Replication has no Node column
                                                                      vmIdSelector: r => r.Guest is long g ? g : null,
                                                                      sourceSelector: r => (string?)r.Source,
                                                                      targetSelector: r => (string?)r.Target));
@@ -322,7 +316,8 @@ public partial class ReportEngine
 
         var subnetResults = await RunParallelAsync(vnetsTask.Result,
                                                    async vnet => (vnet,
-                                                                  subs: await client.Cluster.Sdn.Vnets[vnet.Vnet].Subnets.GetAsync()));
+                                                                  subs: await client.Cluster.Sdn.Vnets[vnet.Vnet].Subnets.GetAsync()
+                                                                                    .ToSafeEnum(_issues, "Cluster", LinkKey.Cluster)));
         sw.AddTable("SDN Subnets",
                     subnetResults.SelectMany(r => r.subs.Select(subnet => new
                     {
@@ -362,8 +357,13 @@ public partial class ReportEngine
 
         ReportGlobal("Cluster: Pools");
         var poolResults = await RunParallelAsync(poolsTask.Result,
-                                                 async pool => { var detail = await client.Pools[pool.Id].GetAsync(); return (pool, detail.Members); });
-        var poolRows = poolResults.SelectMany(r => r.Members.Select(member => new
+                                                 async pool =>
+                                                 {
+                                                     var detail = await client.Pools[pool.Id].GetAsync()
+                                                                              .ToSafeSingle(_issues, "Cluster", LinkKey.Cluster);
+                                                     return (pool, members: detail?.Members ?? []);
+                                                 });
+        var poolRows = poolResults.SelectMany(r => r.members.Select(member => new
         {
             Pool = r.pool.Id,
             member.Type,
@@ -394,7 +394,7 @@ public partial class ReportEngine
                         a.Comment
                     }));
 
-        if (haGroupsSupported && haGroupsTask != null)
+        if (haGroupsSupported)
         {
             sw.AddTable("HA Groups",
                         haGroupsTask.Result.Select(a => new

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.ClusterLog.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.ClusterLog.cs
@@ -14,13 +14,14 @@ public partial class ReportEngine
     {
         if (!settings.Cluster.Log.Enabled) { return 0; }
 
-        var logs = (await client.Cluster.Log.GetAsync(max: settings.Cluster.Log.MaxCount > 0
+        var logs = await client.Cluster.Log.GetAsync(max: settings.Cluster.Log.MaxCount > 0
                                                             ? settings.Cluster.Log.MaxCount
-                                                            : null)).ToList();
+                                                            : null)
+                               .ToSafeEnum(_issues, "Cluster Log", LinkKey.ClusterLog);
 
         using var sw = _writer.AddSection("Cluster Log");
         sw.AddTable(null,
-                    logs.ConvertAll(a => new
+                    logs.Select(a => new
                     {
                         a.TimeDate,
                         a.Node,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.ClusterTasks.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.ClusterTasks.cs
@@ -14,11 +14,12 @@ public partial class ReportEngine
     {
         if (!settings.Cluster.IncludeTasks) { return 0; }
 
-        var tasks = (await client.Cluster.Tasks.GetAsync()).ToList();
+        var tasks = await client.Cluster.Tasks.GetAsync()
+                                .ToSafeEnum(_issues, "Cluster Tasks", LinkKey.ClusterTasks);
 
         using var sw = _writer.AddSection("Cluster Tasks");
         sw.AddTable(null,
-                    tasks.ConvertAll(a => new
+                    tasks.Select(a => new
                     {
                         a.Node,
                         a.UniqueTaskId,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
@@ -25,19 +25,10 @@ public partial class ReportEngine
         pt.Next(item);
 
         pt.Step("Config");
-        VmConfigLxc? config;
-        try
-        {
-            config = item.IsUnknown
+        var config = item.IsUnknown
                         ? null
-                        : await client.Nodes[item.Node].Lxc[item.VmId].Config.GetAsync();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to read config for CT {item.VmId} on node '{item.Node}' (name: '{item.Name}'). See inner exception for details.",
-                ex);
-        }
+                        : await client.Nodes[item.Node].Lxc[item.VmId].Config.GetAsync()
+                                      .ToSafeSingle(_issues, "Container", LinkKey.Vm(item.VmId));
 
         var networks = new List<VmNetworkRow>();
         if (config != null)
@@ -154,7 +145,7 @@ public partial class ReportEngine
         var config = d.Config!;
         using var sw = _writer.AddSection(new SectionId.Container(d.Item.VmId, d.Item.Name ?? ""));
 
-        sw.AddBackLink("Containers", LinkKey.ListContainers());
+        sw.AddBackLink("Containers", LinkKey.ListContainers);
 
         var mainKv = new Dictionary<string, object?>
         {
@@ -205,15 +196,12 @@ public partial class ReportEngine
         if (settings.Firewall.Enabled && settings.Guest.Detail.IncludeFirewallLog)
         {
             pt.Step("Firewall Logs");
-            AddLogs(sw,
-                    "Firewall Logs",
-                    await client.Nodes[d.Item.Node]
-                                .Lxc[d.Item.VmId]
-                                .Firewall
-                                .Log
-                                .GetAsync(limit: settings.Firewall.Limit,
-                                          since: settings.Firewall.SinceUnix,
-                                          until: settings.Firewall.UntilUnix));
+            var fwLogs = await client.Nodes[d.Item.Node].Lxc[d.Item.VmId].Firewall.Log
+                                     .GetAsync(limit: settings.Firewall.Limit,
+                                               since: settings.Firewall.SinceUnix,
+                                               until: settings.Firewall.UntilUnix)
+                                     .ToSafeEnum(_issues, "Firewall Log", LinkKey.Vm(d.Item.VmId));
+            AddLogs(sw, "Firewall Logs", fwLogs);
         }
 
         await AddGuestTasksTableAsync(sw, pt, d.Item.Node, d.Item.VmId);

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Firewall.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Firewall.cs
@@ -122,8 +122,8 @@ public partial class ReportEngine
                 var (rulesRaw, aliasesRaw, ipSetsRaw) = item.VmType switch
                 {
                     VmType.Qemu => (vmFw.Rules.GetAsync(), vmFw.Aliases.GetAsync(), vmFw.Ipset.GetAsync()),
-                    VmType.Lxc  => (ctFw.Rules.GetAsync(), ctFw.Aliases.GetAsync(), ctFw.Ipset.GetAsync()),
-                    _           => throw new InvalidOperationException($"unexpected VM type {item.VmType}"),
+                    VmType.Lxc => (ctFw.Rules.GetAsync(), ctFw.Aliases.GetAsync(), ctFw.Ipset.GetAsync()),
+                    _ => throw new InvalidOperationException($"unexpected VM type {item.VmType}"),
                 };
 
                 var vmLink = LinkKey.Vm(item.VmId);

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Firewall.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Firewall.cs
@@ -86,22 +86,23 @@ public partial class ReportEngine
         }
 
         ReportGlobal("Firewall: Cluster");
-        var clusterRulesTask = client.Cluster.Firewall.Rules.GetAsync();
-        var clusterAliasesTask = client.Cluster.Firewall.Aliases.GetAsync();
-        var clusterIpSetsTask = client.Cluster.Firewall.Ipset.GetAsync();
-        await TaskExtensions.WhenAllSafe(clusterRulesTask, clusterAliasesTask, clusterIpSetsTask);
+        var clusterRulesTask = client.Cluster.Firewall.Rules.GetAsync().ToSafeEnum(_issues, "Firewall", LinkKey.Firewall);
+        var clusterAliasesTask = client.Cluster.Firewall.Aliases.GetAsync().ToSafeEnum(_issues, "Firewall", LinkKey.Firewall);
+        var clusterIpSetsTask = client.Cluster.Firewall.Ipset.GetAsync().ToSafeEnum(_issues, "Firewall", LinkKey.Firewall);
+        await Task.WhenAll(clusterRulesTask, clusterAliasesTask, clusterIpSetsTask);
 
-        AppendRules("cluster", "cluster", "", clusterRulesTask.ResultOrDefault() ?? []);
-        AppendAliases("cluster", "cluster", "", clusterAliasesTask.ResultOrDefault() ?? []);
-        AppendIpSets("cluster", "cluster", "", clusterIpSetsTask.ResultOrDefault() ?? []);
+        AppendRules("cluster", "cluster", "", clusterRulesTask.Result);
+        AppendAliases("cluster", "cluster", "", clusterAliasesTask.Result);
+        AppendIpSets("cluster", "cluster", "", clusterIpSetsTask.Result);
 
         var nodeFirewallResults = await RunParallelAsync(
             GetResources(ClusterResourceType.Node).Where(a => !a.IsUnknown),
             async item =>
             {
                 ReportGlobal($"Firewall: Node {item.Node}");
-                return (scope: item.Node,
-                        rules: await client.Nodes[item.Node].Firewall.Rules.GetAsync());
+                var rules = await client.Nodes[item.Node].Firewall.Rules.GetAsync()
+                                        .ToSafeEnum(_issues, "Firewall", LinkKey.Node(item.Node));
+                return (scope: item.Node, rules);
             });
 
         foreach (var (scope, rules) in nodeFirewallResults.OrderBy(r => r.scope))
@@ -115,33 +116,28 @@ public partial class ReportEngine
             {
                 ReportGlobal($"Firewall: {item.VmType} {item.VmId}");
 
-                Task<IEnumerable<FirewallRule>> rulesTask;
-                Task<IEnumerable<FirewallAlias>> aliasesTask;
-                Task<IEnumerable<FirewallIpSet>> ipSetsTask;
+                var vmFw = client.Nodes[item.Node].Qemu[item.VmId].Firewall;
+                var ctFw = client.Nodes[item.Node].Lxc[item.VmId].Firewall;
 
-                if (item.VmType == VmType.Qemu)
+                var (rulesRaw, aliasesRaw, ipSetsRaw) = item.VmType switch
                 {
-                    var vmFw = client.Nodes[item.Node].Qemu[item.VmId].Firewall;
-                    rulesTask = vmFw.Rules.GetAsync();
-                    aliasesTask = vmFw.Aliases.GetAsync();
-                    ipSetsTask = vmFw.Ipset.GetAsync();
-                }
-                else
-                {
-                    var ctFw = client.Nodes[item.Node].Lxc[item.VmId].Firewall;
-                    rulesTask = ctFw.Rules.GetAsync();
-                    aliasesTask = ctFw.Aliases.GetAsync();
-                    ipSetsTask = ctFw.Ipset.GetAsync();
-                }
+                    VmType.Qemu => (vmFw.Rules.GetAsync(), vmFw.Aliases.GetAsync(), vmFw.Ipset.GetAsync()),
+                    VmType.Lxc  => (ctFw.Rules.GetAsync(), ctFw.Aliases.GetAsync(), ctFw.Ipset.GetAsync()),
+                    _           => throw new InvalidOperationException($"unexpected VM type {item.VmType}"),
+                };
 
-                await TaskExtensions.WhenAllSafe(rulesTask, aliasesTask, ipSetsTask);
+                var vmLink = LinkKey.Vm(item.VmId);
+                var rulesTask = rulesRaw.ToSafeEnum(_issues, "Firewall", vmLink);
+                var aliasesTask = aliasesRaw.ToSafeEnum(_issues, "Firewall", vmLink);
+                var ipSetsTask = ipSetsRaw.ToSafeEnum(_issues, "Firewall", vmLink);
+                await Task.WhenAll(rulesTask, aliasesTask, ipSetsTask);
 
                 return (scopeType: item.Type,
                         scope: item.VmId.ToString(),
                         scopeName: item.Name,
-                        rules: rulesTask.ResultOrDefault() ?? [],
-                        aliases: aliasesTask.ResultOrDefault() ?? [],
-                        ipSets: ipSetsTask.ResultOrDefault() ?? []);
+                        rules: rulesTask.Result,
+                        aliases: aliasesTask.Result,
+                        ipSets: ipSetsTask.Result);
             });
 
         foreach (var (scopeType, scope, scopeName, rules, aliases, ipSets) in guestFirewallResults.OrderBy(r => r.scope))

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Issues.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Issues.cs
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Diagnostics;
+using Corsinvest.ProxmoxVE.Report.Writers;
+
+namespace Corsinvest.ProxmoxVE.Report;
+
+public partial class ReportEngine
+{
+    /// <summary>
+    /// Writes the Issues section to the report and prepends a stat entry so it shows up
+    /// as the second item on the cover. No-op when there are no collected issues.
+    /// </summary>
+    private void AddIssuesSection(List<SectionStat> stats, Stopwatch sw)
+    {
+        if (!_issues.HasAny) { return; }
+
+        ReportGlobal("Issues");
+        sw.Restart();
+
+        using var section = _writer.AddSection("Issues");
+        section.AddTable(null,
+                         _issues.All.Select(a => new
+                         {
+                             Severity = a.Severity.ToString(),
+                             a.Section,
+                             MessageWrap = a.Message,
+                             a.Timestamp,
+                             a.LinkKey,
+                         }),
+                         new TableOptions<dynamic>().WithColumnLink("Section", r => (string?)r.LinkKey));
+
+        stats.Insert(0, new("Issues", "Warnings and errors collected during report generation", _issues.All.Count, sw.Elapsed));
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Node.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Node.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.ProxmoxVE.Api;
 using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
@@ -33,23 +32,24 @@ public partial class ReportEngine
 
         pt.Step("Status/Version/Subscription/DNS/Time/Network");
         var node = client.Nodes[item.Node];
-        var statusTask = node.Status.GetAsync();
-        var versionTask = node.Version.GetAsync();
-        var subscriptionTask = node.Subscription.GetAsync();
-        var dnsTask = node.Dns.GetAsync();
-        var timeTask = node.Time.GetAsync();
-        var networksTask = node.Network.GetAsync();
-        await TaskExtensions.WhenAllSafe(statusTask, versionTask, subscriptionTask, dnsTask, timeTask, networksTask);
+        var nodeLink = LinkKey.Node(item.Node);
+        var statusTask = node.Status.GetAsync().ToSafeSingle(_issues, "Node", nodeLink);
+        var versionTask = node.Version.GetAsync().ToSafeSingle(_issues, "Node", nodeLink);
+        var subscriptionTask = node.Subscription.GetAsync().ToSafeSingle(_issues, "Node", nodeLink);
+        var dnsTask = node.Dns.GetAsync().ToSafeSingle(_issues, "Node", nodeLink);
+        var timeTask = node.Time.GetAsync().ToSafeSingle(_issues, "Node", nodeLink);
+        var networksTask = node.Network.GetAsync().ToSafeEnum(_issues, "Node", nodeLink);
+        await Task.WhenAll(statusTask, versionTask, subscriptionTask, dnsTask, timeTask, networksTask);
 
         return new()
         {
             Item = item,
-            Status = statusTask.ResultOrDefault(),
-            Version = versionTask.ResultOrDefault(),
-            Subscription = subscriptionTask.ResultOrDefault(),
-            Dns = dnsTask.ResultOrDefault(),
-            Time = timeTask.ResultOrDefault(),
-            Networks = networksTask.ResultOrDefault() ?? [],
+            Status = statusTask.Result,
+            Version = versionTask.Result,
+            Subscription = subscriptionTask.Result,
+            Dns = dnsTask.Result,
+            Time = timeTask.Result,
+            Networks = networksTask.Result,
         };
     }
 
@@ -138,7 +138,7 @@ public partial class ReportEngine
     {
         var node = data.Item.Node;
         using var sw = _writer.AddSection(new SectionId.Node(node));
-        sw.AddBackLink("Nodes", LinkKey.ListNodes());
+        sw.AddBackLink("Nodes", LinkKey.ListNodes);
 
         sw.AddKeyValue(node,
                        new Dictionary<string, object?>
@@ -170,22 +170,22 @@ public partial class ReportEngine
                        });
 
         pt.Step("Services/SSL Certificates/Hosts");
-        var servicesTask = client.Nodes[node].Services.GetAsync();
-        var certificatesTask = client.Nodes[node].Certificates.Info.GetAsync();
-        var hostsTask = client.Nodes[node].Hosts.GetEtcHosts();
+        var servicesTask = client.Nodes[node].Services.GetAsync().ToSafeEnum(_issues, "Node", LinkKey.Node(node));
+        var certificatesTask = client.Nodes[node].Certificates.Info.GetAsync().ToSafeEnum(_issues, "Node", LinkKey.Node(node));
+        var hostsTextTask = client.Nodes[node].Hosts.GetEtcHosts().ToSafeText(_issues, "Node", LinkKey.Node(node));
 
-        await TaskExtensions.WhenAllSafe(servicesTask, certificatesTask, hostsTask);
+        await Task.WhenAll(servicesTask, certificatesTask, hostsTextTask);
 
         sw.AddTable("Services",
-                       (servicesTask.ResultOrDefault() ?? []).Select(a => new
-                       {
-                           a.Name,
-                           a.Service,
-                           a.State,
-                           a.ActiveState,
-                           a.UnitState,
-                           DescriptionWrap = a.Description,
-                       }));
+                    servicesTask.Result.Select(a => new
+                    {
+                        a.Name,
+                        a.Service,
+                        a.State,
+                        a.ActiveState,
+                        a.UnitState,
+                        DescriptionWrap = a.Description,
+                    }));
 
         sw.AddTable("Network",
                     data.Networks.Select(a => new
@@ -234,9 +234,8 @@ public partial class ReportEngine
                     }).ToList(),
                     new TableOptions<dynamic>().WithRowKeys(r => [LinkKey.NodeNetwork(node, (string)r.Interface)]));
 
-        var hostsResult = hostsTask.ResultOrDefault();
         sw.AddTable("/etc/hosts",
-                       (hostsResult is null ? "" : (string)hostsResult.ToData().data)
+                    hostsTextTask.Result
                                 .Split('\n')
                                 .Select(a => a.Trim())
                                 .Where(a => a.Length > 0 && !a.StartsWith('#'))
@@ -253,7 +252,8 @@ public partial class ReportEngine
 
         if (settings.Node.Detail.Disk.IncludeDiskDetail || settings.Node.Detail.Disk.IncludeSmartData)
         {
-            var disksData = await client.Nodes[node].Disks.List.GetAsync(include_partitions: true);
+            var disksData = await client.Nodes[node].Disks.List.GetAsync(include_partitions: true)
+                                        .ToSafeEnum(_issues, "Node", LinkKey.Node(node));
 
             if (settings.Node.Detail.Disk.IncludeDiskDetail)
             {
@@ -310,12 +310,12 @@ public partial class ReportEngine
             if (settings.Node.Detail.Disk.IncludeDiskDetail)
             {
                 pt.Step("Directory/ZFS Pools");
-                var directoryTask = client.Nodes[node].Disks.Directory.GetAsync();
-                var zfsPoolsListTask = client.Nodes[node].Disks.Zfs.GetAsync();
-                await TaskExtensions.WhenAllSafe(directoryTask, zfsPoolsListTask);
+                var directoryTask = client.Nodes[node].Disks.Directory.GetAsync().ToSafeEnum(_issues, "Node", LinkKey.Node(node));
+                var zfsPoolsListTask = client.Nodes[node].Disks.Zfs.GetAsync().ToSafeEnum(_issues, "Node", LinkKey.Node(node));
+                await Task.WhenAll(directoryTask, zfsPoolsListTask);
 
                 sw.AddTable("Directory",
-                            (directoryTask.ResultOrDefault() ?? []).Select(a => new
+                            directoryTask.Result.Select(a => new
                             {
                                 a.Device,
                                 a.Path,
@@ -324,8 +324,11 @@ public partial class ReportEngine
                                 a.UnitFile
                             }));
 
-                var zfsPoolList = (zfsPoolsListTask.ResultOrDefault() ?? []).ToList();
-                var zfsPoolDetails = await RunParallelAsync(zfsPoolList, p => client.Nodes[node].Disks.Zfs[p.Name].GetAsync());
+                var zfsPoolList = zfsPoolsListTask.Result.ToList();
+                var zfsPoolDetails = await RunParallelAsync(zfsPoolList,
+                    async p => await client.Nodes[node].Disks.Zfs[p.Name].GetAsync()
+                                           .ToSafeSingle(_issues, "Node", LinkKey.Node(node))
+                               ?? new NodeDiskZfsDetail());
 
                 sw.AddTable("ZFS Pools",
                             zfsPoolList.Zip(zfsPoolDetails, (pool, poolData) => new
@@ -354,12 +357,12 @@ public partial class ReportEngine
         if (settings.Node.Detail.IncludeApt)
         {
             pt.Step("Apt Repository/Updates/Versions");
-            var aptRepositoriesTask = client.Nodes[node].Apt.Repositories.GetAsync();
-            var aptUpdatesTask = client.Nodes[node].Apt.Update.GetAsync();
-            var aptVersionsTask = client.Nodes[node].Apt.Versions.GetAsync();
-            await TaskExtensions.WhenAllSafe(aptRepositoriesTask, aptUpdatesTask, aptVersionsTask);
+            var aptRepositoriesTask = client.Nodes[node].Apt.Repositories.GetAsync().ToSafeSingle(_issues, "Node", LinkKey.Node(node));
+            var aptUpdatesTask = client.Nodes[node].Apt.Update.GetAsync().ToSafeEnum(_issues, "Node", LinkKey.Node(node));
+            var aptVersionsTask = client.Nodes[node].Apt.Versions.GetAsync().ToSafeEnum(_issues, "Node", LinkKey.Node(node));
+            await Task.WhenAll(aptRepositoriesTask, aptUpdatesTask, aptVersionsTask);
 
-            var aptRepositories = aptRepositoriesTask.ResultOrDefault();
+            var aptRepositories = aptRepositoriesTask.Result;
             sw.AddTable("Apt Repository",
                         (aptRepositories?.Files ?? []).SelectMany(a => a.Repositories, (file, repo) => new
                         {
@@ -374,7 +377,7 @@ public partial class ReportEngine
                         }));
 
             sw.AddTable("Apt Update",
-                        (aptUpdatesTask.ResultOrDefault() ?? []).Select(a => new
+                        aptUpdatesTask.Result.Select(a => new
                         {
                             a.Package,
                             a.Version,
@@ -388,7 +391,7 @@ public partial class ReportEngine
                         }));
 
             sw.AddTable("Package Version",
-                        (aptVersionsTask.ResultOrDefault() ?? []).Select(a => new
+                        aptVersionsTask.Result.Select(a => new
                         {
                             a.Package,
                             a.Version,
@@ -406,15 +409,15 @@ public partial class ReportEngine
         if (settings.Firewall.Enabled && settings.Node.Detail.IncludeFirewallLog)
         {
             pt.Step("Firewall Logs");
-            AddLogs(sw,
-                    "Firewall Logs",
-                    await client.Nodes[node].Firewall.Log.GetAsync(limit: settings.Firewall.Limit,
-                                                                   since: settings.Firewall.SinceUnix,
-                                                                   until: settings.Firewall.UntilUnix));
+            var fwLogs = await client.Nodes[node].Firewall.Log.GetAsync(limit: settings.Firewall.Limit,
+                                                                        since: settings.Firewall.SinceUnix,
+                                                                        until: settings.Firewall.UntilUnix)
+                                     .ToSafeEnum(_issues, "Firewall Log", LinkKey.Node(node));
+            AddLogs(sw, "Firewall Logs", fwLogs);
         }
 
         sw.AddTable("SSL Certificates",
-                    (certificatesTask.ResultOrDefault() ?? []).Select(cert => new
+                    certificatesTask.Result.Select(cert => new
                     {
                         cert.FileName,
                         cert.Subject,
@@ -438,7 +441,7 @@ public partial class ReportEngine
                                 errors: taskSettings.OnlyErrors ? true : null,
                                 limit: taskSettings.MaxCount > 0 ? taskSettings.MaxCount : null,
                                 source: taskSettings.Source == "all" ? null : taskSettings.Source
-                            )).Select(a => new
+                            ).ToSafeEnum(_issues, "Node", LinkKey.Node(node))).Select(a => new
                             {
                                 a.UniqueTaskId,
                                 a.Type,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Replication.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Replication.cs
@@ -25,33 +25,35 @@ public partial class ReportEngine
         var results = await RunParallelAsync(nodes, async item =>
         {
             ReportGlobal($"Replication: {item.Node}");
+            var data = await client.Nodes[item.Node].Replication
+                                   .GetAsync()
+                                   .ToSafeEnum(_issues, "Replication", LinkKey.Node(item.Node));
             return (item.Node,
-                    rows: (await client.Nodes[item.Node].Replication.GetAsync())
-                        .Select(a => new
-                        {
-                            item.Node,
-                            a.Id,
-                            a.Type,
-                            a.VmType,
-                            VmId = a.Guest,
-                            GuestName = long.TryParse(a.Guest, out var guestId)
+                    rows: data.Select(a => new
+                    {
+                        item.Node,
+                        a.Id,
+                        a.Type,
+                        a.VmType,
+                        VmId = a.Guest,
+                        GuestName = long.TryParse(a.Guest, out var guestId)
                                             && _resourcesByVmId.TryGetValue(guestId, out var guestRes)
                                             ? guestRes.Name ?? ""
                                             : "",
-                            a.Source,
-                            a.Target,
-                            a.Schedule,
-                            a.Disable,
-                            a.FailCount,
-                            a.Error,
-                            a.Duration,
-                            a.Rate,
-                            LastSync = FromUnixTime(a.LastSync),
-                            NextSync = FromUnixTime(a.NextSync),
-                            LastTry = FromUnixTime(a.LastTry),
-                            a.JobNum,
-                            CommentWrap = a.Comment,
-                        }).ToList());
+                        a.Source,
+                        a.Target,
+                        a.Schedule,
+                        a.Disable,
+                        a.FailCount,
+                        a.Error,
+                        a.Duration,
+                        a.Rate,
+                        LastSync = FromUnixTime(a.LastSync),
+                        NextSync = FromUnixTime(a.NextSync),
+                        LastTry = FromUnixTime(a.LastTry),
+                        a.JobNum,
+                        CommentWrap = a.Comment,
+                    }).ToList());
         });
 
         var rows = results.OrderBy(r => r.Node).SelectMany(r => r.rows).ToList();

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdGuest.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdGuest.cs
@@ -24,37 +24,38 @@ public partial class ReportEngine
         var results = await RunParallelAsync(guests, async item =>
         {
             ReportGlobal($"RRD Guest: {item.VmId} {item.Name}");
+            var data = await client.GetVmRrdDataAsync(item.Node,
+                                                     item.VmType,
+                                                     item.VmId,
+                                                     settings.Guest.RrdData.TimeFrame,
+                                                     settings.Guest.RrdData.Consolidation)
+                                   .ToSafeEnum(_issues, "RRD Guests", LinkKey.Vm(item.VmId));
             return (item,
-                    rows: (await client.GetVmRrdDataAsync(item.Node,
-                                                         item.VmType,
-                                                         item.VmId,
-                                                         settings.Guest.RrdData.TimeFrame,
-                                                         settings.Guest.RrdData.Consolidation))
-                            .Select(a => new
-                            {
-                                item.Node,
-                                Type = item.VmType.ToString(),
-                                item.VmId,
-                                item.Name,
-                                a.TimeDate,
-                                CpuUsagePct = a.CpuUsagePercentage,
-                                MemorySizeGB = ToGB(a.MemorySize),
-                                MemoryUsageGB = ToGB(a.MemoryUsage),
-                                MemoryUsagePct = a.MemoryUsagePercentage,
-                                NetInMB = ToMB(a.NetIn),
-                                NetOutMB = ToMB(a.NetOut),
-                                DiskReadMB = ToMB(a.DiskRead),
-                                DiskWriteMB = ToMB(a.DiskWrite),
-                                DiskSizeGB = ToGB(a.DiskSize),
-                                DiskUsageGB = ToGB(a.DiskUsage),
-                                DiskUsagePct = a.DiskUsagePercentage,
-                                PsiCpuSomePct = a.PressureCpuSome,
-                                PsiCpuFullPct = a.PressureCpuFull,
-                                PsiIoSomePct = a.PressureIoSome,
-                                PsiIoFullPct = a.PressureIoFull,
-                                PsiMemSomePct = a.PressureMemorySome,
-                                PsiMemFullPct = a.PressureMemoryFull,
-                            }).ToList());
+                    rows: data.Select(a => new
+                    {
+                        item.Node,
+                        Type = item.VmType.ToString(),
+                        item.VmId,
+                        item.Name,
+                        a.TimeDate,
+                        CpuUsagePct = a.CpuUsagePercentage,
+                        MemorySizeGB = ToGB(a.MemorySize),
+                        MemoryUsageGB = ToGB(a.MemoryUsage),
+                        MemoryUsagePct = a.MemoryUsagePercentage,
+                        NetInMB = ToMB(a.NetIn),
+                        NetOutMB = ToMB(a.NetOut),
+                        DiskReadMB = ToMB(a.DiskRead),
+                        DiskWriteMB = ToMB(a.DiskWrite),
+                        DiskSizeGB = ToGB(a.DiskSize),
+                        DiskUsageGB = ToGB(a.DiskUsage),
+                        DiskUsagePct = a.DiskUsagePercentage,
+                        PsiCpuSomePct = a.PressureCpuSome,
+                        PsiCpuFullPct = a.PressureCpuFull,
+                        PsiIoSomePct = a.PressureIoSome,
+                        PsiIoFullPct = a.PressureIoFull,
+                        PsiMemSomePct = a.PressureMemorySome,
+                        PsiMemFullPct = a.PressureMemoryFull,
+                    }).ToList());
         });
 
         var rows = results.OrderBy(r => r.item.Id).SelectMany(r => r.rows).ToList();

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdNode.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdNode.cs
@@ -5,7 +5,6 @@
 
 using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
-using Corsinvest.ProxmoxVE.Api.Shared.Models.Common;
 using Corsinvest.ProxmoxVE.Report.Writers;
 
 namespace Corsinvest.ProxmoxVE.Report;
@@ -23,36 +22,35 @@ public partial class ReportEngine
 
         if (nodes.Count == 0) { return 0; }
 
-        var rrdTimeFrame = settings.Node.RrdData.TimeFrame.GetValue();
-        var rrdConsolidation = settings.Node.RrdData.Consolidation.GetValue();
-
         var results = await RunParallelAsync(nodes, async item =>
         {
             ReportGlobal($"RRD Nodes: {item.Node}");
+            var data = await client.Nodes[item.Node].Rrddata
+                                   .GetAsync(settings.Node.RrdData.TimeFrame, settings.Node.RrdData.Consolidation)
+                                   .ToSafeEnum(_issues, "RRD Nodes", LinkKey.Node(item.Node));
             return (item,
-                    rows: (await client.Nodes[item.Node].Rrddata.GetAsync(rrdTimeFrame, rrdConsolidation))
-                            .Select(a => new
-                            {
-                                item.Node,
-                                a.TimeDate,
-                                CpuUsagePct = a.CpuUsagePercentage,
-                                a.IoWait,
-                                a.Loadavg,
-                                MemorySizeGB = ToGB(a.MemorySize),
-                                MemoryUsageGB = ToGB(a.MemoryUsage),
-                                MemoryUsagePct = a.MemoryUsagePercentage,
-                                SwapSizeGB = ToGB(a.SwapSize),
-                                SwapUsageGB = ToGB(a.SwapUsage),
-                                RootSizeGB = ToGB(a.RootSize),
-                                RootUsageGB = ToGB(a.RootUsage),
-                                NetInMB = ToMB(a.NetIn),
-                                NetOutMB = ToMB(a.NetOut),
-                                PsiCpuSomePct = a.PressureCpuSome,
-                                PsiIoSomePct = a.PressureIoSome,
-                                PsiIoFullPct = a.PressureIoFull,
-                                PsiMemSomePct = a.PressureMemorySome,
-                                PsiMemFullPct = a.PressureMemoryFull,
-                            }).ToList());
+                    rows: data.Select(a => new
+                    {
+                        item.Node,
+                        a.TimeDate,
+                        CpuUsagePct = a.CpuUsagePercentage,
+                        a.IoWait,
+                        a.Loadavg,
+                        MemorySizeGB = ToGB(a.MemorySize),
+                        MemoryUsageGB = ToGB(a.MemoryUsage),
+                        MemoryUsagePct = a.MemoryUsagePercentage,
+                        SwapSizeGB = ToGB(a.SwapSize),
+                        SwapUsageGB = ToGB(a.SwapUsage),
+                        RootSizeGB = ToGB(a.RootSize),
+                        RootUsageGB = ToGB(a.RootUsage),
+                        NetInMB = ToMB(a.NetIn),
+                        NetOutMB = ToMB(a.NetOut),
+                        PsiCpuSomePct = a.PressureCpuSome,
+                        PsiIoSomePct = a.PressureIoSome,
+                        PsiIoFullPct = a.PressureIoFull,
+                        PsiMemSomePct = a.PressureMemorySome,
+                        PsiMemFullPct = a.PressureMemoryFull,
+                    }).ToList());
         });
 
         var rows = results.OrderBy(r => r.item.Id).SelectMany(r => r.rows).ToList();

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdStorage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdStorage.cs
@@ -4,7 +4,6 @@
  */
 
 using Corsinvest.ProxmoxVE.Api.Extension;
-using Corsinvest.ProxmoxVE.Api.Shared.Models.Common;
 using Corsinvest.ProxmoxVE.Report.Writers;
 
 namespace Corsinvest.ProxmoxVE.Report;
@@ -18,23 +17,22 @@ public partial class ReportEngine
         var filtered = _uniqueStorages.OrderBy(a => a.Id).ToList();
         if (filtered.Count == 0) { return 0; }
 
-        var rrdTimeFrame = settings.Storage.RrdData.TimeFrame.GetValue();
-        var rrdConsolidation = settings.Storage.RrdData.Consolidation.GetValue();
-
         var results = await RunParallelAsync(filtered, async item =>
         {
             ReportGlobal($"RRD Storage: {item.Node} {item.Storage}");
+            var data = await client.Nodes[item.Node].Storage[item.Storage].Rrddata
+                                   .GetAsync(settings.Storage.RrdData.TimeFrame, settings.Storage.RrdData.Consolidation)
+                                   .ToSafeEnum(_issues, "RRD Storage", LinkKey.Node(item.Node));
             return (item,
-                    rows: (await client.Nodes[item.Node].Storage[item.Storage].Rrddata.GetAsync(rrdTimeFrame, rrdConsolidation))
-                        .Select(a => new
-                        {
-                            Node = StorageNode(item),
-                            item.Storage,
-                            a.TimeDate,
-                            SizeGB = ToGB(a.Size),
-                            UsedGB = ToGB(a.Used),
-                            UsagePct = a.Size > 0 ? (double)a.Used / a.Size : (double?)null,
-                        }).ToList());
+                    rows: data.Select(a => new
+                    {
+                        Node = StorageNode(item),
+                        item.Storage,
+                        a.TimeDate,
+                        SizeGB = ToGB(a.Size),
+                        UsedGB = ToGB(a.Used),
+                        UsagePct = a.Size > 0 ? (double)a.Used / a.Size : (double?)null,
+                    }).ToList());
         });
 
         var rows = results.OrderBy(r => r.item.Id).SelectMany(r => r.rows).ToList();

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Snapshots.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Snapshots.cs
@@ -5,6 +5,7 @@
 
 using Corsinvest.ProxmoxVE.Api.Extension.Utils;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 using Corsinvest.ProxmoxVE.Report.Writers;
 
 namespace Corsinvest.ProxmoxVE.Report;
@@ -27,7 +28,15 @@ public partial class ReportEngine
             ReportGlobal($"Snapshots: {item.Node} {item.VmId}");
 
             var rows = new List<dynamic>();
-            foreach (var snapshot in await SnapshotHelper.GetSnapshotsAsync(client, item.Node, item.VmType, item.VmId))
+            IEnumerable<VmSnapshot> snapshots;
+            try { snapshots = await SnapshotHelper.GetSnapshotsAsync(client, item.Node, item.VmType, item.VmId); }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _issues.Warning("Snapshots", ex.Message, LinkKey.Vm(item.VmId));
+                return (item, rows);
+            }
+
+            foreach (var snapshot in snapshots)
             {
                 rows.Add(new
                 {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.StorageContent.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.StorageContent.cs
@@ -36,7 +36,9 @@ public partial class ReportEngine
         {
             ReportGlobal($"Storage Content: {item.Node} {item.Storage}");
 
-            var allContent = await client.Nodes[item.Node].Storage[item.Storage].Content.GetAsync();
+            var allContent = await client.Nodes[item.Node].Storage[item.Storage].Content
+                                         .GetAsync()
+                                         .ToSafeEnum(_issues, "Storage Content", LinkKey.Node(item.Node));
             var storageSize = item.DiskSize;
 
             var contentRows = settings.Storage.IncludeContent

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Syslog.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Syslog.cs
@@ -65,12 +65,14 @@ public partial class ReportEngine
         {
             ReportGlobal($"Syslog: {item.Node}");
 
-            var rows = (await client.Nodes[item.Node]
+            var lines = await client.Nodes[item.Node]
                                     .Journal
                                     .GetAsync(lastentries: settings.Node.Syslog.Limit,
                                               since: settings.Node.Syslog.SinceUnix,
-                                              until: settings.Node.Syslog.UntilUnix))
-                            .Select(a => ParseSyslogLine(item.Node, a)).ToList();
+                                              until: settings.Node.Syslog.UntilUnix)
+                                    .ToSafeEnum(_issues, "Syslog", LinkKey.Node(item.Node));
+
+            var rows = lines.Select(a => ParseSyslogLine(item.Node, a)).ToList();
 
             if (table == null)
             {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
@@ -31,19 +31,10 @@ public partial class ReportEngine
         pt.Next(item);
 
         pt.Step("Config");
-        VmConfigQemu? config;
-        try
-        {
-            config = item.IsUnknown
+        var config = item.IsUnknown
                         ? null
-                        : await client.Nodes[item.Node].Qemu[item.VmId].Config.GetAsync();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"Failed to read config for VM {item.VmId} on node '{item.Node}' (name: '{item.Name}'). See inner exception for details.",
-                ex);
-        }
+                        : await client.Nodes[item.Node].Qemu[item.VmId].Config.GetAsync()
+                                      .ToSafeSingle(_issues, "VM", LinkKey.Vm(item.VmId));
 
         VmQemuAgentOsInfo? agentOsInfo = null;
         var hostname = "";
@@ -135,6 +126,7 @@ public partial class ReportEngine
                     // Include short exception detail so issues like timeouts, auth errors, or
                     // agent-returned errors can be diagnosed without re-running with a debugger.
                     var msg = ex.InnerException?.Message ?? ex.Message;
+                    _issues.Warning("VM Detail", msg, LinkKey.Vm(item.VmId));
                     hostname = $"Agent not running! ({msg})";
                 }
             }
@@ -276,7 +268,7 @@ public partial class ReportEngine
     {
         var config = d.Config!;
         using var sw = _writer.AddSection(new SectionId.Vm(d.Item.VmId, d.Item.Name ?? ""));
-        sw.AddBackLink("VMs", LinkKey.ListVms());
+        sw.AddBackLink("VMs", LinkKey.ListVms);
 
         var mainKv = new Dictionary<string, object?>
         {
@@ -365,15 +357,12 @@ public partial class ReportEngine
         if (settings.Firewall.Enabled && settings.Guest.Detail.IncludeFirewallLog)
         {
             pt.Step("Firewall Logs");
-            AddLogs(sw,
-                    "Firewall Logs",
-                    await client.Nodes[d.Item.Node]
-                                .Qemu[d.Item.VmId]
-                                .Firewall
-                                .Log
-                                .GetAsync(limit: settings.Firewall.Limit,
-                                          since: settings.Firewall.SinceUnix,
-                                          until: settings.Firewall.UntilUnix));
+            var fwLogs = await client.Nodes[d.Item.Node].Qemu[d.Item.VmId].Firewall.Log
+                                     .GetAsync(limit: settings.Firewall.Limit,
+                                               since: settings.Firewall.SinceUnix,
+                                               until: settings.Firewall.UntilUnix)
+                                     .ToSafeEnum(_issues, "Firewall Log", LinkKey.Vm(d.Item.VmId));
+            AddLogs(sw, "Firewall Logs", fwLogs);
         }
 
         await AddGuestTasksTableAsync(sw, pt, d.Item.Node, d.Item.VmId);

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
@@ -36,6 +36,7 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
     private readonly List<(ClusterResource Vm, IEnumerable<VmDisk> Disks)> _pendingDiskRows = [];
     private readonly List<(ClusterResource Vm, IEnumerable<VmQemuAgentGetFsInfo.ResultInfo> Partitions)> _pendingPartitionRows = [];
     private HashSet<long> _vmIds = [];
+    private readonly IssueTracker _issues = new();
     private IReportWriter _writer = null!;
 
     private record VmNetworkRow(long VmId,
@@ -85,10 +86,10 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
 
         _storageConfigs = await client.Storage.GetAsync();
 
-        _writer.Links[LinkKey.Storage()] = "Storages";
-        _writer.Links[LinkKey.ListNodes()] = "Nodes";
-        _writer.Links[LinkKey.ListVms()] = "VMs";
-        _writer.Links[LinkKey.ListContainers()] = "Containers";
+        _writer.Links[LinkKey.Storages] = "Storages";
+        _writer.Links[LinkKey.ListNodes] = "Nodes";
+        _writer.Links[LinkKey.ListVms] = "VMs";
+        _writer.Links[LinkKey.ListContainers] = "Containers";
 
         foreach (var item in _resources)
         {
@@ -144,36 +145,40 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
 
         await LoadResourcesAsync();
 
-        var sections = new Dictionary<string, Func<Task<int>>>
+        var sections = new Section[]
         {
-            ["Cluster"] = () => AddClusterDataAsync(),
-            ["Storages"] = () => AddStoragesDataAsync(),
-            ["Nodes"] = () => AddNodesDataAsync(),
-            ["VMs"] = () => AddVmsDataAsync(),
-            ["Containers"] = () => AddContainersDataAsync(),
-            ["Network"] = () => Task.FromResult(WriteNetworkData()),
-            ["Storage Content"] = () => AddStorageContentDataAsync(),
-            ["Disks"] = () => Task.FromResult(WriteDiskData()),
-            ["Partitions"] = () => Task.FromResult(WritePartitionData()),
-            ["Snapshots"] = () => AddSnapshotsDataAsync(),
-            ["Firewall"] = () => AddFirewallDataAsync(),
-            ["Replication"] = () => AddReplicationDataAsync(),
-            ["RRD Nodes"] = () => AddRrdNodeDataAsync(),
-            ["RRD Storage"] = () => AddRrdStorageDataAsync(),
-            ["RRD Guests"] = () => AddRrdGuestDataAsync(),
-            ["Syslog"] = () => AddSyslogDataAsync(),
-            ["Cluster Log"] = () => AddClusterLogDataAsync(),
-            ["Cluster Tasks"] = () => AddClusterTasksDataAsync(),
+            new("Cluster", "Cluster overview, users, roles, ACL, firewall, backup jobs", AddClusterDataAsync),
+            new("Storages", "Storage list with size, usage and type", AddStoragesDataAsync),
+            new("Nodes", "Node list with hardware, subscription, DNS, kernel details", AddNodesDataAsync),
+            new("VMs", "Virtual machines (QEMU) with agent info, OS name/version/kernel, bios, cpu, memory and disk details", AddVmsDataAsync),
+            new("Containers", "LXC containers with hostname, swap, nameserver and privilege details", AddContainersDataAsync),
+            new("Network", "Global network overview: node interfaces and VM/CT network inventory", () => Task.FromResult(WriteNetworkData())),
+            new("Storage Content", "Storage content inventory (ISO, templates, disk images — excludes backups)", AddStorageContentDataAsync),
+            new("Disks", "Global disk inventory: VM/CT disk configuration", () => Task.FromResult(WriteDiskData())),
+            new("Partitions", "Guest filesystem partitions with used/total space from QEMU agent", () => Task.FromResult(WritePartitionData())),
+            new("Snapshots", "Global snapshot inventory across all VMs and containers", AddSnapshotsDataAsync),
+            new("Firewall", "Global firewall rules, aliases and IPSets across cluster, nodes, VMs and containers", AddFirewallDataAsync),
+            new("Replication", "Global replication status across all nodes: last sync, next sync, errors and duration", AddReplicationDataAsync),
+            new("RRD Nodes", "Historical performance data (CPU, memory, swap, disk, network) for all nodes", AddRrdNodeDataAsync),
+            new("RRD Storage", "Historical performance data (size, used, usage%) for all storages", AddRrdStorageDataAsync),
+            new("RRD Guests", "Historical performance data (CPU, memory, disk, network) for all VMs and containers", AddRrdGuestDataAsync),
+            new("Syslog", "Systemd journal per node parsed into date, time, host, service, pid and message", AddSyslogDataAsync),
+            new("Cluster Log", "Cluster log with user, node, service and message", AddClusterLogDataAsync),
+            new("Cluster Tasks", "All recent tasks across the cluster with status, duration and node", AddClusterTasksDataAsync),
         };
 
         var stats = new List<SectionStat>();
         var sw = Stopwatch.StartNew();
-        foreach (var (name, action) in sections)
+        foreach (var s in sections)
         {
-            ReportGlobal(name);
+            ReportGlobal(s.Name);
             sw.Restart();
-            stats.Add(new(name, await action(), sw.Elapsed));
+            stats.Add(new(s.Name, s.Description, await s.Action(), sw.Elapsed));
         }
+
+        // Issues is generated last (so it sees every section's failures) and surfaced as the
+        // second cover entry (right after Cluster) when non-empty.
+        AddIssuesSection(stats, sw);
 
         ReportGlobal("Network Diagram");
         BuildAndStoreNetworkDiagramSvg();
@@ -283,8 +288,9 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
 
         pt.Step("Tasks");
         var rows = (await client.Nodes[node].Tasks.GetAsync(errors: TrueOrNull(settings.Guest.Detail.Tasks.OnlyErrors),
-                                                            limit: IntOrNull(settings.Guest.Detail.Tasks.MaxCount),
-                                                            vmid: (int)vmId))
+                                                             limit: IntOrNull(settings.Guest.Detail.Tasks.MaxCount),
+                                                             vmid: (int)vmId)
+                                .ToSafeEnum(_issues, "Guest Tasks", LinkKey.Vm(vmId)))
                        .Select(a => new
                        {
                            a.UniqueTaskId,

--- a/src/Corsinvest.ProxmoxVE.Report/Section.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Section.cs
@@ -1,0 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report;
+
+internal sealed record Section(string Name, string Description, Func<Task<int>> Action);

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.CoverPage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.CoverPage.cs
@@ -15,6 +15,7 @@ internal sealed partial class HtmlReportWriter
         var rows = string.Concat(statsList.Select(s => $"""
                   <tr>
                     <td><a href="{HtmlEncoder.PageHref(s.Name)}">{HtmlEncoder.Text(s.Name)}</a></td>
+                    <td>{HtmlEncoder.Text(s.Description)}</td>
                     <td class="num">{s.Count}</td>
                     <td class="num">{FormatDuration(s.Duration)}</td>
                   </tr>
@@ -49,11 +50,11 @@ internal sealed partial class HtmlReportWriter
                     <h2>Contents</h2>
                     <div class="table-scroll">
                       <table class="data">
-                        <thead><tr><th>Section</th><th>Rows</th><th>Duration</th></tr></thead>
+                        <thead><tr><th>Section</th><th>Description</th><th>Rows</th><th>Duration</th></tr></thead>
                         <tbody>
             {{rows}}      </tbody>
                         <tfoot>
-                          <tr><th>Total</th><th class="num"></th><th class="num">{{FormatDuration(totalDuration)}}</th></tr>
+                          <tr><th>Total</th><th></th><th class="num"></th><th class="num">{{FormatDuration(totalDuration)}}</th></tr>
                         </tfoot>
                       </table>
                     </div>

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.Sidebar.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.Sidebar.cs
@@ -45,6 +45,11 @@ internal sealed partial class HtmlReportWriter
         sb.AppendLine("""      <nav id="sidebar-nav">""");
         sb.AppendLine("""        <a href="index.html" class="overview">Home</a>""");
 
+        if (sectionNames.Contains("Issues"))
+        {
+            sb.AppendLine("""        <a href="issues.html" class="overview">Issues</a>""");
+        }
+
         if (_networkDiagramSvg is { Length: > 0 })
         {
             sb.AppendLine("""        <a href="network-diagram.html" class="overview">Network Diagram</a>""");

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.cs
@@ -24,6 +24,10 @@ internal sealed partial class HtmlReportWriter(ReportInfo info) : IReportWriter
     {
         Links[id.Key] = id.Key;
 
+        // Auto-register the canonical section:* key so tables in other pages
+        // can hyperlink to this page via LinkKey.ForSection(name).
+        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = id.Key; }
+
         var displayName = id switch
         {
             SectionId.Vm v => string.IsNullOrWhiteSpace(v.DisplayLabel)

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/LinkKey.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/LinkKey.cs
@@ -12,13 +12,61 @@ namespace Corsinvest.ProxmoxVE.Report.Writers;
 /// </summary>
 internal static class LinkKey
 {
+    // Per-entity keys (parameterised).
     public static string Node(string node) => $"node:{node}";
     public static string Vm(long vmId) => $"vm:{vmId}";
-    public static string Storage() => "storage:link";
-    public static string List(string what) => $"list:{what}";
     public static string NodeNetwork(string node, string iface) => $"node:{node}:network:{iface}";
+    public static string List(string what) => $"list:{what}";
 
-    public static string ListNodes() => List("nodes");
-    public static string ListVms() => List("vms");
-    public static string ListContainers() => List("containers");
+    // Named list keys.
+    public const string ListNodes = "list:nodes";
+    public const string ListVms = "list:vms";
+    public const string ListContainers = "list:containers";
+
+    // Global section pages — each maps 1:1 to a section name. Writers auto-register
+    // them in AddSection via ForSection(name).
+    public const string Cluster = "section:cluster";
+    public const string ClusterLog = "section:cluster-log";
+    public const string ClusterTasks = "section:cluster-tasks";
+    public const string Storages = "section:storages";
+    public const string StorageContent = "section:storage-content";
+    public const string Backups = "section:backups";
+    public const string Disks = "section:disks";
+    public const string Partitions = "section:partitions";
+    public const string Snapshots = "section:snapshots";
+    public const string Network = "section:network";
+    public const string Firewall = "section:firewall";
+    public const string Replication = "section:replication";
+    public const string RrdNodes = "section:rrd-nodes";
+    public const string RrdStorage = "section:rrd-storage";
+    public const string RrdGuests = "section:rrd-guests";
+    public const string Syslog = "section:syslog";
+    public const string Issues = "section:issues";
+
+    /// <summary>
+    /// Returns the canonical <c>section:*</c> key for a top-level section name,
+    /// or null if the name doesn't map to a known global page.
+    /// </summary>
+    public static string? ForSection(string sectionName)
+        => sectionName switch
+        {
+            "Cluster" => Cluster,
+            "Cluster Log" => ClusterLog,
+            "Cluster Tasks" => ClusterTasks,
+            "Storages" => Storages,
+            "Storage Content" => StorageContent,
+            "Backups" => Backups,
+            "Disks" => Disks,
+            "Partitions" => Partitions,
+            "Snapshots" => Snapshots,
+            "Network" => Network,
+            "Firewall" => Firewall,
+            "Replication" => Replication,
+            "RRD Nodes" => RrdNodes,
+            "RRD Storage" => RrdStorage,
+            "RRD Guests" => RrdGuests,
+            "Syslog" => Syslog,
+            "Issues" => Issues,
+            _ => null,
+        };
 }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/SectionStat.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/SectionStat.cs
@@ -5,4 +5,4 @@
 
 namespace Corsinvest.ProxmoxVE.Report.Writers;
 
-internal sealed record SectionStat(string Name, int Count, TimeSpan Duration);
+internal sealed record SectionStat(string Name, string Description, int Count, TimeSpan Duration);

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/TableOptionsExtensions.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/TableOptionsExtensions.cs
@@ -19,7 +19,7 @@ internal static class TableOptionsExtensions
         => options.WithColumnLink("VmId", row => vmIdSelector(row) is long id and > 0 ? LinkKey.Vm(id) : null);
 
     public static TableOptions<T> WithStorageLink<T>(this TableOptions<T> options, Func<T, string?> storageSelector)
-        => options.WithColumnLink("Storage", row => string.IsNullOrWhiteSpace(storageSelector(row)) ? null : LinkKey.Storage());
+        => options.WithColumnLink("Storage", row => string.IsNullOrWhiteSpace(storageSelector(row)) ? null : LinkKey.Storages);
 
     /// <summary>Replication tables link Node, VmId, Source (node) and Target (node) in one go.</summary>
     public static TableOptions<T> WithReplicationLinks<T>(this TableOptions<T> options,

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/SheetWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/SheetWriter.cs
@@ -252,7 +252,7 @@ internal sealed class SheetWriter(IXLWorksheet ws, Dictionary<string, string> sh
                             "Storage",
                             cell => string.IsNullOrWhiteSpace(cell.Value.ToString())
                                     ? null
-                                    : LinkKey.Storage());
+                                    : LinkKey.Storages);
 
     public void RegisterNetworkLinks(IXLTable table, string node)
         => RegisterRowLinks(table, "Interface", cell => LinkKey.NodeNetwork(node, cell.Value.ToString()));

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/XlsxReportWriter.CoverPage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/XlsxReportWriter.CoverPage.cs
@@ -66,85 +66,6 @@ internal sealed partial class XlsxReportWriter
 
         AddHeader("Contents");
 
-        var sections = new List<(string, string)>();
-
-        if (settings.Cluster.Include)
-        {
-            sections.Add(("Cluster", "Cluster overview, users, roles, ACL, firewall, backup jobs"));
-        }
-
-        sections.Add(("Nodes", "Node list with hardware, subscription, DNS, kernel details"));
-        sections.Add(("VMs", "Virtual machines (QEMU) with agent info, OS name/version/kernel, bios, cpu, memory and disk details"));
-        sections.Add(("Containers", "LXC containers with hostname, swap, nameserver and privilege details"));
-
-        if (settings.Guest.IncludeDisks)
-        {
-            sections.Add(("Disks", "Global disk inventory: VM/CT disk configuration"));
-        }
-
-        if (settings.Guest.IncludePartitions && settings.Guest.IncludeQemuAgent)
-        {
-            sections.Add(("Partitions", "Guest filesystem partitions with used/total space from QEMU agent"));
-        }
-
-        if (settings.Guest.IncludeSnapshots)
-        {
-            sections.Add(("Snapshots", "Global snapshot inventory across all VMs and containers"));
-        }
-
-        sections.Add(("Network", "Global network overview: node interfaces and VM/CT network inventory"));
-        sections.Add(("Storages", "Storage list with size, usage and type"));
-
-        if (settings.Storage.IncludeContent)
-        {
-            sections.Add(("Storage Content", "Storage content inventory (ISO, templates, disk images — excludes backups)"));
-        }
-
-        if (settings.Storage.IncludeBackups)
-        {
-            sections.Add(("Backups", "Backup inventory across all storages with protection, encryption and verification status"));
-        }
-
-        if (settings.Firewall.Enabled)
-        {
-            sections.Add(("Firewall", "Global firewall rules, aliases and IPSets across cluster, nodes, VMs and containers"));
-        }
-
-        if (settings.Node.IncludeReplication)
-        {
-            sections.Add(("Replication", "Global replication status across all nodes: last sync, next sync, errors and duration"));
-        }
-
-        if (settings.Node.RrdData.Enabled)
-        {
-            sections.Add(("RRD Nodes", "Historical performance data (CPU, memory, swap, disk, network) for all nodes"));
-        }
-
-        if (settings.Storage.RrdData.Enabled)
-        {
-            sections.Add(("RRD Storage", "Historical performance data (size, used, usage%) for all storages"));
-        }
-
-        if (settings.Guest.RrdData.Enabled)
-        {
-            sections.Add(("RRD Guests", "Historical performance data (CPU, memory, disk, network) for all VMs and containers"));
-        }
-
-        if (settings.Node.Syslog.Enabled)
-        {
-            sections.Add(("Syslog", "Systemd journal per node parsed into date, time, host, service, pid and message"));
-        }
-
-        if (settings.Cluster.Log.Enabled)
-        {
-            sections.Add(("Cluster Log", "Cluster log with user, node, service and message"));
-        }
-
-        if (settings.Cluster.IncludeTasks)
-        {
-            sections.Add(("Cluster Tasks", "All recent tasks across the cluster with status, duration and node"));
-        }
-
         ws.Cell(row, 1).Value = "Sheet";
         ws.Cell(row, 2).Value = "Description";
         ws.Cell(row, 3).Value = "Count";
@@ -158,24 +79,19 @@ internal sealed partial class XlsxReportWriter
 
         var statsList = stats.ToList();
 
-        foreach (var (sheetName, description) in sections)
+        foreach (var stat in statsList)
         {
-            ws.Cell(row, 1).Value = sheetName;
+            ws.Cell(row, 1).Value = stat.Name;
             ws.Cell(row, 1).Style.Font.SetUnderline(XLFontUnderlineValues.Single);
             ws.Cell(row, 1).Style.Font.SetFontColor(XLColor.Blue);
 
-            var actualSheet = _workbook.Worksheets.FirstOrDefault(s => s.Name.StartsWith(sheetName[..Math.Min(sheetName.Length, MaxSheetNameLength)]))?.Name ?? sheetName;
+            var actualSheet = _workbook.Worksheets.FirstOrDefault(s => s.Name.StartsWith(stat.Name[..Math.Min(stat.Name.Length, MaxSheetNameLength)]))?.Name ?? stat.Name;
             ws.Cell(row, 1).SetHyperlink(new XLHyperlink($"'{actualSheet}'!A1"));
-            ws.Cell(row, 2).Value = description;
-
-            var stat = statsList.FirstOrDefault(s => string.Equals(s.Name, sheetName, StringComparison.OrdinalIgnoreCase));
-            if (stat != null)
-            {
-                ws.Cell(row, 3).Value = stat.Count;
-                ws.Cell(row, 4).Value = stat.Duration.TotalSeconds < 60
-                    ? $"{stat.Duration.TotalSeconds:F1}s"
-                    : $"{stat.Duration.TotalMinutes:F1}m";
-            }
+            ws.Cell(row, 2).Value = stat.Description;
+            ws.Cell(row, 3).Value = stat.Count;
+            ws.Cell(row, 4).Value = stat.Duration.TotalSeconds < 60
+                ? $"{stat.Duration.TotalSeconds:F1}s"
+                : $"{stat.Duration.TotalMinutes:F1}m";
 
             row++;
         }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/XlsxReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/XlsxReportWriter.cs
@@ -54,6 +54,11 @@ internal sealed partial class XlsxReportWriter : IReportWriter
 
         var ws = _workbook.Worksheets.Add(safeName);
         var sheet = new SheetWriter(ws, Links);
+
+        // Auto-register the canonical section:* key so tables in other sheets
+        // can hyperlink to this page via LinkKey.ForSection(name).
+        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = safeName; }
+
         return new XlsxSectionWriter(sheet);
     }
 
@@ -109,6 +114,7 @@ internal sealed partial class XlsxReportWriter : IReportWriter
                           .OrderBy(w => int.TryParse(w.Name[(prefix.Length + 1)..], out var n) ? n : int.MaxValue));
 
         PlaceByPrefix("Summary");
+        PlaceByPrefix("Issues");
         PlaceByPrefix("Cluster");
         PlaceByPrefix("Nodes");
         PlaceByPrefix("VMs");


### PR DESCRIPTION
## Summary

Fixes #33 — a single failing Proxmox endpoint (corrupt RRD file on one storage, `500` on a node, missing permissions on a sub-resource, …) no longer aborts the whole report.

- Failures are collected during the run into a dedicated **Issues** page.
- Each issue carries severity, section, the full Proxmox error message (status + body + endpoint) and a hyperlink back to the relevant detail page (VM / Node / Storage / global section).
- HTTP `501 Not Implemented` is silent (endpoint missing in older PVE versions); everything else surfaces as a `Warning` the user can act on.
- The Issues page only appears when there is something to report — second tab after `Summary` in XLSX, second sidebar link after `Home` in HTML, also second entry in the Contents table on the cover.
- Both formats now show a per-section **Description** column on the cover, consistent between Excel and HTML.

## What's in here

### Core
- New `IssueTracker` / `Issue` records ([Issue.cs](src/Corsinvest.ProxmoxVE.Report/Issue.cs), [IssueTracker.cs](src/Corsinvest.ProxmoxVE.Report/IssueTracker.cs)) — collected during the run, materialised as the Issues section.
- New safe helpers in [PveResultExtensions.cs](src/Corsinvest.ProxmoxVE.Report/PveResultExtensions.cs):
  - `ToSafeEnum<T>(this Task<IEnumerable<T>>, IssueTracker, section, linkKey)` — for SDK extension calls returning collections.
  - `ToSafeSingle<T>(this Task<T>, IssueTracker, section, linkKey)` — for single-object calls.
  - `ToSafeText(this Task<Result>, IssueTracker, section, linkKey)` — for raw text endpoints (`/etc/hosts`).
  All three classify `PveResultException` via `ClassifyHttpStatus` (501 silent, rest Warning) and capture the API path + body in the `Message` for diagnostics.
- All 25+ per-resource and global API calls migrated to the new helpers — including the bulk parallel block in `ReportEngine.Cluster.cs` that previously rilanced on any 4xx/5xx. Bootstrap calls (cluster Version/Status, GetResourcesAsync, …) intentionally still fail-fast: if PVE is unreachable, there is no report to generate.
- VM agent (`Vm.cs:65-95`) intentionally kept on the existing `WhenAllSafe` / `ResultOrDefault` pattern — its agent failures already had semantic fallbacks (`"Agent timeout!"`, `"Agent not running!"`) which now also feed an Issue entry.

### Link wiring
- [LinkKey.cs](src/Corsinvest.ProxmoxVE.Report/Writers/LinkKey.cs) extended with `const` keys for every global page (`Cluster`, `Snapshots`, `Firewall`, `Replication`, …) and a `ForSection(name)` mapper.
- `XlsxReportWriter.AddSection` and `HtmlReportWriter.AddSection` auto-register `section:*` keys, so any Issue with `LinkKey.Cluster` / `LinkKey.Firewall` / … is automatically clickable.
- Per-entity links (`LinkKey.Node(...)`, `LinkKey.Vm(...)`) work via the existing rendering pipeline.

### Cover / layout
- New `Section` record ([Section.cs](src/Corsinvest.ProxmoxVE.Report/Section.cs)) holds `Name + Description + Action` — the single source of truth for section ordering and description text.
- `SectionStat` gains a `Description` field, populated by `ReportEngine` and consumed by both cover writers.
- The hard-coded description map in `XlsxReportWriter.CoverPage.cs` is gone (20 entries) — HTML cover gains the matching column.

### Documentation
- [CHANGELOG.md](CHANGELOG.md) — new `2.2.0` section.
- [README.md](README.md) — "Resilient by design" paragraph in the header, new capability row, new bullet under "What's collected", Issues page mentioned in the features list.

## Sample diagnostic message

For Jan's case (#33), a corrupt RRD file on `orion/local-ceph` now produces:

```
Severity: Warning
Section:  RRD Storage          ← hyperlink to RRD Storage sheet/page
Message:  500 Internal Server Error — got wrong time resolution (60 != 1800) — GET /nodes/orion/storage/local-ceph/rrddata
```

The rest of the report generates normally; the affected storage gets an empty section and surfaces the failure here instead.

## Test plan

- [ ] `cv4pve-report ... export` (Xlsx, default) — Issues sheet present and 2nd tab when any endpoint fails, absent otherwise.
- [ ] `cv4pve-report ... export --format Html` — `issues.html` present and 2nd sidebar link when any endpoint fails, absent otherwise.
- [ ] Click an Issue row → lands on the right VM / Node / Storage / global page.
- [ ] Empty cover Description column in HTML aligned to XLSX cover.
- [ ] PVE 9.x cluster: HA Groups still skipped via `haGroupsSupported` version-gate (no false Warning).
- [ ] PVE 8.3.x cluster: `/cluster/mapping/dir` 501 still silent.
- [ ] Build is clean on net8/9/10.

Closes #33.