### PR TITLE
docs: unify format-xlsx/format-html structure + document Issues page

### DIFF
--- a/docs/format-html.md
+++ b/docs/format-html.md
@@ -2,10 +2,6 @@
 
 `--format Html` produces a self-contained zipped static website. Extract the zip and open `index.html` in any browser — works fully offline, no server needed.
 
-```
-Report_20260506_120000.zip    ← static website (extract and open index.html)
-```
-
 ---
 
 ## File layout inside the zip
@@ -13,6 +9,7 @@ Report_20260506_120000.zip    ← static website (extract and open index.html)
 ```
 Report_20260506_120000.zip
 ├── index.html                 ← cover / home page
+├── issues.html                ← only present when at least one collection failure was recorded
 ├── network-diagram.html       ← network topology page
 ├── network-diagram.svg        ← raw SVG (embedded by network-diagram.html)
 │
@@ -52,62 +49,69 @@ Report_20260506_120000.zip
     └── export-data.js         ← CSS + table.js inlined for the standalone export
 ```
 
-The same logical sections produced by the XLSX format become **one HTML page each** — see the [Excel format guide](format-xlsx.md) for the per-section table contents (the data is identical, only the rendering differs).
+---
+
+## Sections
+
+Pages appear in this order in the sidebar. Conditional pages (`if …`) are only emitted when the matching setting is enabled or when the underlying data exists.
+
+| # | Page | Description | Condition |
+|---|------|-------------|-----------|
+| 1 | **Home** (`index.html`) | Cover with metadata, filters, hyperlinked Contents table | always |
+| 2 | **Issues** (`issues.html`) | Diagnostics for collection failures — see [Issues](#issues) below | only when failures recorded |
+| 3 | **Network Diagram** (`network-diagram.html`) | Topology SVG with embedded view | always when the SVG was generated |
+| 4 | **Cluster** (`cluster.html`) | Cluster-wide configuration and security (users, ACL, firewall options, backup jobs, HA, SDN, pools, hardware mappings) | `Cluster.Include` |
+| 5 | **Nodes** (`nodes.html` + `nodes/<name>.html`) | Node overview → per-node detail pages | always |
+| 6 | **VMs** (`vms.html` + `vms/<id>.html`) | VM overview → per-VM detail pages | always |
+| 7 | **Containers** (`containers.html` + `containers/<id>.html`) | Container overview → per-CT detail pages | always |
+| 8 | **Network** (`network.html`) | Node interfaces + VM/CT NICs (MAC, bridge, VLAN, IPs, model) | always |
+| 9 | **Storages** (`storages.html`) | Storage list with size, usage, type | always |
+| 10 | **Storage Content** (`storage-content.html`) | Storage files/images with size and VM ID links | `Storage.IncludeContent` |
+| 11 | **Backups** (`backups.html`) | Backup files across all storages | `Storage.IncludeBackups` |
+| 12 | **Disks** (`disks.html`) | Global VM/CT disk inventory | `Guest.IncludeDisks` |
+| 13 | **Partitions** (`partitions.html`) | Guest disk partitions via QEMU agent | `Guest.IncludePartitions` |
+| 14 | **Snapshots** (`snapshots.html`) | Global snapshot inventory across all VMs/CTs | `Guest.IncludeSnapshots` |
+| 15 | **Firewall** (`firewall.html`) | Cluster + node + VM/CT firewall rules, aliases, IP sets | `Firewall.Enabled` |
+| 16 | **Replication** (`replication.html`) | Replication job status across all nodes | `Node.IncludeReplication` |
+| 17 | **RRD Nodes** (`rrd-nodes.html`) | Historical performance metrics per node | `Node.RrdData.Enabled` |
+| 18 | **RRD Storage** (`rrd-storages.html`) | Historical performance metrics per storage | `Storage.RrdData.Enabled` |
+| 19 | **RRD Guests** (`rrd-guests.html`) | Historical performance metrics per VM/CT | `Guest.RrdData.Enabled` |
+| 20 | **Syslog** (`syslog.html`) | Parsed systemd journal across all nodes | `Node.Syslog.Enabled` |
+| 21 | **Cluster Log** (`cluster-log.html`) | Cluster event log | `Cluster.Log.Enabled` |
+| 22 | **Cluster Tasks** (`cluster-tasks.html`) | Recent tasks across the cluster | `Cluster.IncludeTasks` |
+
+> The contents of each page (which tables, which columns) are emitted by the engine and identical across formats — see [`docs/settings.md`](settings.md) for the toggles.
+
+The sidebar groups Nodes / VMs / Containers under expandable headers, and Storage / Performance under synthetic groups, but the underlying ordering is the table above.
 
 ---
 
-## Sidebar
+## Issues
 
-Every page shares the same sidebar. Top-level entries are organised into expandable groups:
+When one or more Proxmox API calls fail during collection (a corrupt RRD file, a `500` from a node, missing permissions on a sub-resource, …), an extra `issues.html` page is emitted as the **second** sidebar link, right after Home. It also appears as the **first** row of the Contents table on the cover. On a healthy cluster the page (and the link) are absent.
 
-- **Cluster** (overview + Cluster Log + Cluster Tasks)
-- **Nodes** (overview + per-node detail pages)
-- **VMs** (overview + per-VM detail pages)
-- **Containers** (overview + per-CT detail pages)
-- **Storage** (Storages + Storage Content + Backups + Disks + Partitions + Snapshots)
-- **Network**, **Firewall**, **Replication** (single-page sections)
-- **Performance** (RRD Nodes + RRD Guests + RRD Storage + Syslog)
+| Column | Content |
+|---|---|
+| Severity | `Warning` (default) — `501 Not Implemented` is silent and never appears here. |
+| Section | The logical section where the failure happened (e.g. `RRD Storage`, `Firewall Log`, `Cluster`). **Hyperlinked** to the page where the user can investigate — VM / Node / Storage / global section. |
+| Message | Diagnostic line built from the Proxmox response: HTTP status, the API error body and the failing endpoint, joined with `—`. Example: `500 Internal Server Error — got wrong time resolution (60 != 1800) — GET /nodes/orion/storage/local-ceph/rrddata`. |
+| Timestamp | When the failure was recorded. |
 
-The current page is highlighted in blue. A search box at the top of the sidebar filters all entries by id or name (numeric queries match by id prefix, e.g. `102` matches `102 — opnsense-cc02` but not `1020 — db`).
-
----
-
-## Theme
-
-Light and dark themes are bundled. Click the sun/moon icon in the top-right of the sidebar to toggle. The choice is persisted across pages via `localStorage`. Without an explicit choice, the report follows the OS preference (`prefers-color-scheme`).
+The page uses the same per-table search and click-to-sort as the rest of the report, so filtering by severity or section is immediate.
 
 ---
 
-## Per-page features
+## HTML-specific behaviour
 
-- **Sortable columns** — click any table header to cycle through ascending → descending → original order. The "original order" step is the order the engine emitted (e.g. nodes by hostname, snapshots by date), so a third click always returns the table to its initial state.
-- **Global filter** — every table with at least 5 rows gets a `Filter rows…` box above it. Match defaults to **contains** (`~`); click the small toggle on the left of the box to switch to **exact** (`=`), which matches only rows where at least one cell equals the typed text — useful for short numeric ids like a VM id where `100` would otherwise also match `1014`, `260509100047` and so on.
-- **Per-column filter** — column headers backed by short text, flag, or hyperlinked values (e.g. `Node`, `VmId`, `Status`, `Type`) carry a small funnel icon, hidden until you hover. Click it to reveal a dedicated filter input under the header for that column. Each per-column filter has its own `~`/`=` toggle. Global filter and per-column filters combine with AND.
-- **Page-level Index** — the top of every detail page lists the tables on that page as anchor links.
+- **Sidebar** — every page shares the same navigation. Top-level entries are organised into expandable groups (Cluster / Nodes / VMs / Containers / Storage / Performance) plus flat links (Network, Firewall, Replication, Issues, Network Diagram). The current page is highlighted; a search box filters all entries by id or name (numeric queries match by id prefix, e.g. `102` matches `102 — opnsense-cc02` but not `1020 — db`).
+- **Light & dark theme** — toggle via the sun/moon icon in the top-right of the sidebar; persisted in `localStorage`, defaults to OS preference (`prefers-color-scheme`).
+- **Sortable columns** — click any table header to cycle through ascending → descending → original order. The third click restores the order the engine emitted (e.g. nodes by hostname, snapshots by date).
+- **Global filter** — every table with at least 5 rows gets a `Filter rows…` box above it. Match defaults to **contains** (`~`); the toggle on the left switches to **exact** (`=`), useful for short numeric ids where `100` would otherwise also match `1014`, `260509100047`, etc.
+- **Per-column filter** — column headers backed by short text, flag, or hyperlinked values carry a hover-revealed funnel icon. Click it to reveal a per-column input. Each has its own `~`/`=` toggle. Global + per-column filters combine with AND.
+- **Page-level Index** — every detail page starts with anchor links to the tables on that page.
 - **Print stylesheet** — `Ctrl+P` produces a clean printout: sidebar, filters and sort controls hidden, tables compacted with repeating headers.
+- **Export button** — every node, VM and container detail page has an **Export** button (top right). One click downloads a self-contained `vms-100-standalone.html` (or similar) with CSS and per-table interactions inlined — paste it into a ticket, email it or drop it on a wiki without sending the full report. The exported page has no sidebar and no cross-page links, but keeps the current theme and the table behaviour.
+- **Built for large clusters** — the sidebar lazy-loads its long groups (Nodes, VMs, Containers) from a shared `assets/sidebar-data.js`, so even on **2700+ VM clusters** the report stays fast and the zip stays small. Each detail page only carries its own content; navigation chrome is identical across pages and the browser caches the shared assets.
+- **Network topology SVG** — bundled in the same zip and shown via `network-diagram.html`. The SVG carries an explicit `viewBox` and scales correctly inside the report and when opened standalone. See the [network diagram guide](network-diagram.md) for the legend and layout.
 
 > Filters are intentionally minimal — `~`/`=` covers the day-to-day cases. For regex, multi-criteria, range filters or pivots, the `report.xlsx` shipped in the same `.zip` has Excel's full autofilter built-in.
-
----
-
-## Export button
-
-Every node, VM and container detail page has an **Export** button (top right). One click downloads a self-contained `vms-100-standalone.html` (or similar) with CSS and per-table interactions inlined — paste it into a ticket, attach it to an email or drop it on a wiki without sending the full report.
-
-The exported page:
-- Has no sidebar
-- Has no cross-page links (links to other pages are converted to plain text; in-page anchors are preserved)
-- Keeps the current theme (light/dark)
-- Keeps sort & search behaviour for tables
-
----
-
-## Built for large clusters
-
-The sidebar lazy-loads its long groups (Nodes, VMs, Containers) from a shared `assets/sidebar-data.js`, so even on **2700+ VM clusters** the report stays fast and the zip stays small. Each detail page only carries its own content; the navigation skeleton is identical across pages and the browser caches the shared assets.
-
----
-
-## Network topology SVG
-
-Bundled inside the zip as `network-diagram.svg` and shown via `network-diagram.html` (sidebar entry "Network Diagram"). The SVG carries an explicit `viewBox` and scales correctly inside the report and when opened standalone — see the [network diagram guide](network-diagram.md) for the legend and layout.

--- a/docs/format-xlsx.md
+++ b/docs/format-xlsx.md
@@ -2,129 +2,72 @@
 
 `--format Xlsx` (the default) produces a `.zip` containing a workbook with one sheet per section (plus per-resource detail sheets at the end) and the network topology diagram as a separate `.svg`.
 
+Extract the zip and open `report.xlsx` in Excel, LibreOffice Calc or any spreadsheet tool. Open `network-diagram.svg` in any browser.
+
+---
+
+## File layout inside the zip
+
 ```
 Report_20260506_120000.zip
 ├── report.xlsx              ← single workbook with one sheet per section
 └── network-diagram.svg      ← network topology diagram
 ```
 
-Extract the zip and open `report.xlsx` in Excel, LibreOffice Calc or any spreadsheet tool. Open `network-diagram.svg` in any browser.
+---
+
+## Sections
+
+Sheets are written in this order. Conditional sheets (`if …`) are only present when the matching setting is enabled or when the underlying data exists.
+
+| # | Sheet | Description | Condition |
+|---|-------|-------------|-----------|
+| 1 | **Summary** | Report metadata, filters, hyperlinked table of contents | always |
+| 2 | **Issues** | Diagnostics for collection failures — see [Issues](#issues) below | only when failures recorded |
+| 3 | **Cluster** | Cluster-wide configuration and security (users, ACL, firewall options, backup jobs, HA, SDN, pools, hardware mappings) | `Cluster.Include` |
+| 4 | **Nodes** | Node overview → links to per-node detail sheets | always |
+| 5 | **VMs** | VM overview → links to per-VM detail sheets | always |
+| 6 | **Containers** | Container overview → links to per-CT detail sheets | always |
+| 7 | **Network** | Node interfaces + VM/CT NICs (MAC, bridge, VLAN, IPs, model) | always |
+| 8 | **Storages** | Storage list with size, usage, type | always |
+| 9 | **Storage Content** | Storage files/images with size and VM ID links | `Storage.IncludeContent` |
+| 10 | **Backups** | Backup files across all storages | `Storage.IncludeBackups` |
+| 11 | **Disks** | Global VM/CT disk inventory | `Guest.IncludeDisks` |
+| 12 | **Partitions** | Guest disk partitions via QEMU agent | `Guest.IncludePartitions` |
+| 13 | **Snapshots** | Global snapshot inventory across all VMs/CTs | `Guest.IncludeSnapshots` |
+| 14 | **Firewall** | Cluster + node + VM/CT firewall rules, aliases, IP sets | `Firewall.Enabled` |
+| 15 | **Replication** | Replication job status across all nodes | `Node.IncludeReplication` |
+| 16 | **RRD Nodes** | Historical performance metrics per node | `Node.RrdData.Enabled` |
+| 17 | **RRD Storage** | Historical performance metrics per storage | `Storage.RrdData.Enabled` |
+| 18 | **RRD Guests** | Historical performance metrics per VM/CT | `Guest.RrdData.Enabled` |
+| 19 | **Syslog** | Parsed systemd journal across all nodes | `Node.Syslog.Enabled` |
+| 20 | **Cluster Log** | Cluster event log | `Cluster.Log.Enabled` |
+| 21 | **Cluster Tasks** | Recent tasks across the cluster | `Cluster.IncludeTasks` |
+| … | **Node `<name>`** | Per-node detail (services, network, disks, SMART, ZFS, APT, certificates, tasks) | `Node.Detail.Enabled` |
+| … | **VM `<id>`** | Per-VM detail (agent OS info, network, disks, firewall logs, tasks) | `Guest.Detail.Enabled` |
+| … | **CT `<id>`** | Per-CT detail (same as VM) | `Guest.Detail.Enabled` |
+
+> The contents of each sheet (which tables, which columns) are emitted by the engine and identical across formats — see [`docs/settings.md`](settings.md) for the toggles.
 
 ---
 
-## Sheet order
+## Issues
 
-| # | Sheet | Description |
-|---|-------|-------------|
-| 1 | **Summary** | Report metadata, filters, hyperlinked table of contents |
-| 2 | **Cluster** | Cluster-wide configuration and security |
-| 3 | **Nodes** | Node overview table → links to node detail sheets |
-| 4 | **VMs** | VM overview table → links to VM detail sheets |
-| 5 | **Containers** | Container overview table → links to CT detail sheets |
-| 6 | **Disks** | Global physical disk inventory across all nodes |
-| 7 | **Partitions** | Guest disk partitions via QEMU agent |
-| 8 | **Snapshots** | Global snapshot inventory across all VMs/CTs |
-| 9 | **Network** | Global network inventory (node interfaces + VM/CT NICs) |
-| 10 | **Storages** | Storage overview |
-| 11 | **Storage Content** | All storage files/images with size and VM ID links *(if enabled)* |
-| 12 | **Backups** | All backup files across all storages *(if enabled)* |
-| 13 | **Firewall** | Global firewall rules, aliases and IP sets *(if enabled)* |
-| 14 | **Replication** | Global replication job status *(if enabled)* |
-| 15 | **RRD Nodes** | Historical metrics for all nodes *(if enabled)* |
-| 16 | **RRD Storage** | Historical metrics for all storages *(if enabled)* |
-| 17 | **RRD Guests** | Historical metrics for all VMs/CTs *(if enabled)* |
-| 18 | **Syslog** | Parsed systemd journal across all nodes *(if enabled)* |
-| 19 | **Cluster Log** | Cluster event log *(if enabled)* |
-| 20 | **Cluster Tasks** | All recent tasks across the cluster *(if enabled)* |
-| … | **Node `<name>`** | Per-node detail sheets (at end) |
-| … | **VM `<id>`** | Per-VM detail sheets (at end) |
-| … | **CT `<id>`** | Per-CT detail sheets (at end) |
+When one or more Proxmox API calls fail during collection (a corrupt RRD file, a `500` from a node, missing permissions on a sub-resource, …), an extra **Issues** sheet is emitted as the **second** tab right after `Summary` and is also listed at the **top** of the Contents table on Summary itself. On a healthy cluster the sheet (and the Contents row) are absent.
 
----
-
-## Cluster sheet
-
-| Table | Contents |
-|-------|----------|
-| Status | Nodes, quorum, IP addresses, versions, support level |
-| Users | User list with expiry dates |
-| API Tokens | Token list with expiry dates |
-| Two-Factor Authentication | TFA type per user |
-| Groups | Group membership |
-| Roles | Role privileges |
-| ACL | Access control entries |
-| Firewall Options | Global firewall policy |
-| Domains | Authentication realms |
-| Backup Jobs | Scheduled backup job configuration |
-| HA Resources / Groups / Status | High Availability configuration |
-| Metric Servers | External metric server configuration |
-| SDN Zones / VNets / Controllers | Software-defined networking |
-| Hardware Mappings | Directory, PCI and USB mappings |
-| Pools | Resource pools with member list |
-
----
-
-## Node detail sheet
-
-Per-node sheet (linked from the Nodes list), with `← Back` to Nodes. Skipped entirely if `Node.Detail.Enabled = false`.
-
-| Table | Contents |
-|-------|----------|
-| Services | System service status |
-| Network | Interface configuration with IPv4/IPv6, bond, VLAN, OVS details |
-| /etc/hosts | Host name resolution entries |
-| Disks | Physical disk list *(if `Node.Detail.Disk.IncludeDiskDetail`)* |
-| SMART Data | SMART attributes per disk *(if `Node.Detail.Disk.IncludeSmartData`)* |
-| ZFS Pools / ZFS Pool Status | ZFS pool health, usage, vdev tree *(if `Node.Detail.Disk.IncludeDiskDetail`)* |
-| Directory | Filesystem mount points *(if `Node.Detail.Disk.IncludeDiskDetail`)* |
-| APT Repository / APT Update / Package Versions | APT info *(if `Node.Detail.IncludeApt`)* |
-| Firewall Logs | Node firewall log *(if `Firewall.Enabled`)* |
-| SSL Certificates | Certificate validity, expiry, fingerprint |
-| Tasks | Recent task history *(if `Node.Detail.Tasks.Enabled`)* |
-
----
-
-## VM / CT detail sheet
-
-Per-VM/CT sheet (linked from VMs/Containers list), with `← Back` to list. Skipped entirely if `Guest.Detail.Enabled = false`.
-
-| Table | Contents |
-|-------|----------|
-| Agent OS Info | OS name, kernel, version *(QEMU agent, running VMs only)* |
-| Agent Network | Network interfaces from QEMU agent |
-| Agent Disks | Filesystems from QEMU agent |
-| Network | Interface config from VM config |
-| Disks | Disk list with storage, size, cache |
-| Firewall Logs | VM/CT firewall log *(if `Firewall.Enabled`)* |
-| Tasks | Recent task history *(if `Guest.Detail.Tasks.Enabled`)* |
-
----
-
-## Global sheets
-
-**Network** — one table for node interfaces, one for VM/CT NICs (MAC, bridge, VLAN, IPs, model).
-
-**Disks** — Storage Configuration (cluster-level), Storages (per-node usage), VM Disks (all VM/CT disks).
-
-**Partitions** — guest disk partitions read via QEMU agent (node, VM ID, mount point, filesystem, size, used).
-
-**Snapshots** — all snapshots across all VMs/CTs with RAM flag, size *(if available)*, date.
-
-**Firewall** — three tables: Rules, Aliases, IP Sets — each row has ScopeType (cluster/node/qemu/lxc), Scope, ScopeName *(if enabled)*.
-
-**Syslog** — one unified table, each row parsed: Node, Date, Time, Host, Service, PID, Message *(if enabled)*.
-
-**Cluster Log** — cluster event log with TimeDate, Node, User, Service, Severity, Message *(if enabled)*.
-
-**Cluster Tasks** — all recent tasks across the cluster with Node, Type, User, Status, StartTime, Duration *(if enabled)*.
-
-**RRD Nodes / RRD Storage / RRD Guests** — single table per sheet with resource identifier columns + time-series metrics *(if enabled)*.
+| Column | Content |
+|---|---|
+| Severity | `Warning` (default) — `501 Not Implemented` is silent and never appears here. |
+| Section | The logical section where the failure happened (e.g. `RRD Storage`, `Firewall Log`, `Cluster`). **Hyperlinked** to the relevant sheet — VM / Node / Storage / global section — so you can jump from the error to its context. |
+| Message | Diagnostic line built from the Proxmox response: HTTP status, the API error body and the failing endpoint, joined with `—`. Example: `500 Internal Server Error — got wrong time resolution (60 != 1800) — GET /nodes/orion/storage/local-ceph/rrddata`. |
+| Timestamp | When the failure was recorded. |
 
 ---
 
 ## Excel-specific behaviour
 
-- **Hyperlinks everywhere** — click a node, VM or storage in any list to jump straight to its detail sheet; every detail sheet has a `← Back` link to its list.
-- **Per-sheet index** — every detail sheet starts with a clickable index of its tables so you can jump to the section you need.
-- **Native filtering / sorting / pivot** — every table is a real Excel table; use built-in autofilter, sort, slicer or pivot the data without exporting elsewhere.
+- **Hyperlinks everywhere** — click a node, VM or storage in any list to jump straight to its detail sheet. Every detail sheet has a `← Back` link to its overview.
+- **Per-sheet Index** — each detail sheet starts with a clickable index of its tables so you can jump within the sheet (2-column compact layout for resources with many tables).
+- **Native filtering / sorting / pivot** — every table is a real Excel table: built-in autofilter, sort, slicer and pivot work without exporting elsewhere.
 - **Sheet name length** — Excel limits sheet names to 31 characters. Long names (e.g. `Node verylonghostname.example.com`) are automatically truncated; cross-sheet hyperlinks are rewritten to point at the truncated name.
+- **Network topology** — bundled in the same zip as `network-diagram.svg`; open it in any browser. See the [network diagram guide](network-diagram.md) for the legend and layout.


### PR DESCRIPTION
## Summary

Documentation-only update: unify the structure of `format-xlsx.md` and `format-html.md` and document the new Issues page (shipped in 2.2.0).

## What's in here

### Unified scaffolding

Both format guides now follow the same four `##` headers in the same order:

1. `## File layout inside the zip`
2. `## Sections` — single source of truth for sheet/page order with a `# | Section | Description | Condition` table. Easier to keep in sync as new sections are added; reading the two guides side-by-side highlights only the format-specific bits.
3. `## Issues` — new section, same column reference in both formats.
4. `## <Format>-specific behaviour` — single bullet list that consolidates everything that's truly format-specific:
   - **HTML**: sidebar, theme, sort/filter, export button, large-cluster lazy loading, SVG link.
   - **XLSX**: hyperlinks, per-sheet index, autofilter/pivot, sheet name truncation, SVG link.

### Issues page documented

Mirrors what 2.2.0 actually emits:

- **Second** position in both formats (right after `Summary` in XLSX, right after `Home` in HTML).
- Only emitted when at least one collection failure was recorded — absent on healthy clusters.
- Column reference (Severity / Section / Message / Timestamp) identical in both guides.
- `Section` cell is hyperlinked back to the page where the failure happened.

### Cleanup

- Dropped the repetitive per-sheet/per-page table dumps (`Cluster sheet`, `Node detail sheet`, `VM / CT detail sheet`, `Global sheets`). They restated what's already implied by the section names + what's in the settings reference. The new `## Sections` table covers ordering and conditions; the actual columns per section are emitted by the engine and live in the code.
- Net: `format-xlsx.md` shrinks by ~50 lines, `format-html.md` gains ~6 lines (extra Sections table, but the per-page features collapsed into a single bullet list).

## Test plan

- [ ] `grep '^##'` on both guides returns the same four headers in the same order.
- [ ] The conditional flags in the Sections table match the actual `settings.json` keys.
- [ ] Links inside the docs (to `settings.md`, `network-diagram.md`) still resolve.

No code changes.