### PR TITLE
fix: efi/tpm disks listed, SDN vnets drawn in diagram (closes #37, #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ---
 
+## [2.2.1] — 2026-05-13
+
+### Fixes
+
+- **EFI disk and TPM state now listed in the Disks sheet.** `efidisk0` and `tpmstate0` were missing from the per-VM disk inventory because the underlying SDK consumed them into dedicated typed properties instead of leaving them in the generic disk dictionary. They now appear alongside `scsi0`, `virtio0`, etc. with the same columns (storage, format, size). Thanks @shaundeeb for the report (#37).
+- **SDN vnets no longer make VMs disappear from the network diagram.** When a VM was attached to an SDN vnet that wasn't materialised in the node's `/etc/network/interfaces` (typical of zones whose apply hasn't been propagated, Simple/EVPN zones, or datacenter-only vnets), the diagram had no bridge to draw the VM on and the VM was silently dropped. The diagram now learns about SDN vnets from the cluster-wide config and injects the missing bridges as synthetic boxes on every node where the zone is active. Thanks @janrenard for the report (#36).
+
+### What's new
+
+- **Network sheet now includes an SDN Vnets table.** Between *Nodes Networks* and *VM Networks* there is now a third table listing every SDN vnet with its zone, zone type, parent bridge, VLAN tag, alias and the nodes where it's active. Same data was already available in the *Cluster* sheet but it lives natively here too now, so the network view is self-contained.
+
+---
+
 ## [2.2.0] — 2026-05-11
 
 ### What's new

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <Version>2.2.0</Version>
+        <Version>2.2.1</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.16" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.16" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.17" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.17" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs
@@ -64,8 +64,6 @@ public partial class ReportEngine
         var backupJobsTask = client.Cluster.Backup.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
         var replicationTask = client.Cluster.Replication.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
         var metricServersTask = client.Cluster.Metrics.Server.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
-        var sdnZonesTask = client.Cluster.Sdn.Zones.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
-        var vnetsTask = client.Cluster.Sdn.Vnets.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
         var sdnControllersTask = client.Cluster.Sdn.Controllers.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
         var sdnIpamsTask = client.Cluster.Sdn.Ipams.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
         var mappingDirTask = client.Cluster.Mapping.Dir.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
@@ -86,7 +84,7 @@ public partial class ReportEngine
         await Task.WhenAll(
             optionsTask, usersTask, tfaTask, groupsTask, rolesTask, aclTask, domainsTask,
             backupJobsTask, replicationTask, metricServersTask,
-            sdnZonesTask, vnetsTask, sdnControllersTask, sdnIpamsTask,
+            sdnControllersTask, sdnIpamsTask,
             mappingDirTask, mappingPciTask, mappingUsbTask,
             poolsTask, haResourcesTask, haStatusTask,
             fwOptionsTask, haGroupsTask);
@@ -271,7 +269,7 @@ public partial class ReportEngine
 
         ReportGlobal("Cluster: SDN");
         sw.AddTable("SDN Zones",
-                    sdnZonesTask.Result.Select(a => new
+                    _sdnZones.Select(a => new
                     {
                         a.Zone,
                         a.Type,
@@ -285,7 +283,7 @@ public partial class ReportEngine
                     }));
 
         sw.AddTable("SDN Vnets",
-                    vnetsTask.Result.Select(a => new
+                    _sdnVnets.Select(a => new
                     {
                         a.Vnet,
                         a.Zone,
@@ -314,7 +312,7 @@ public partial class ReportEngine
                         a.Type,
                     }));
 
-        var subnetResults = await RunParallelAsync(vnetsTask.Result,
+        var subnetResults = await RunParallelAsync(_sdnVnets,
                                                    async vnet => (vnet,
                                                                   subs: await client.Cluster.Sdn.Vnets[vnet.Vnet].Subnets.GetAsync()
                                                                                     .ToSafeEnum(_issues, "Cluster", LinkKey.Cluster)));

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Network.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Network.cs
@@ -64,6 +64,18 @@ public partial class ReportEngine
         using var sw = _writer.AddSection("Network");
         CreateNodeNetworkTable(sw, "Nodes Networks", _pendingNodeNetworkRows);
 
+        sw.AddTable("SDN Vnets",
+                    _sdnRows.Select(a => new
+                    {
+                        a.Vnet,
+                        a.Zone,
+                        a.ZoneType,
+                        a.ZoneBridge,
+                        a.Tag,
+                        a.Alias,
+                        Nodes = string.Join(", ", a.Nodes),
+                    }));
+
         sw.AddTable("VM Networks",
                     _pendingNetworkRows.ConvertAll(row => new
                     {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
@@ -316,7 +316,6 @@ public partial class ReportEngine
             ["Vga"] = config.Vga,
             ["Agent"] = config.AgentEnabled,
             ["Agent Running"] = d.AgentRunning,
-            ["TPM State"] = config.Tpmstate0,
             ["Watchdog"] = config.Watchdog,
             ["Rng0"] = config.Rng0,
             ["Start Up"] = config.StartUp,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
@@ -33,6 +33,9 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
     private readonly List<VmNetworkRow> _pendingNetworkRows = [];
     private readonly List<(string Node, NodeNetwork Network)> _pendingNodeNetworkRows = [];
     private IEnumerable<StorageItem> _storageConfigs = [];
+    private IReadOnlyList<ClusterSdnVnet> _sdnVnets = [];
+    private IReadOnlyList<ClusterSdnZone> _sdnZones = [];
+    private IReadOnlyList<NetworkDiagramBuilder.SdnVnetRow> _sdnRows = [];
     private readonly List<(ClusterResource Vm, IEnumerable<VmDisk> Disks)> _pendingDiskRows = [];
     private readonly List<(ClusterResource Vm, IEnumerable<VmQemuAgentGetFsInfo.ResultInfo> Partitions)> _pendingPartitionRows = [];
     private HashSet<long> _vmIds = [];
@@ -84,7 +87,31 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
 
         _vmIds = [.. (await client.GetVmsAsync(settings.Guest.Ids)).Select(a => a.VmId)];
 
-        _storageConfigs = await client.Storage.GetAsync();
+        // Cluster-wide bootstrap data, consumed by multiple sections (Cluster sheet, Network
+        // sheet) and the SVG diagram. Loaded once in parallel.
+        var storageTask = client.Storage.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var sdnVnetsTask = client.Cluster.Sdn.Vnets.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        var sdnZonesTask = client.Cluster.Sdn.Zones.GetAsync().ToSafeEnum(_issues, "Cluster", LinkKey.Cluster);
+        await Task.WhenAll(storageTask, sdnVnetsTask, sdnZonesTask);
+
+        _storageConfigs = storageTask.Result;
+        _sdnVnets = sdnVnetsTask.Result;
+        _sdnZones = sdnZonesTask.Result;
+        _sdnRows = [.. _sdnVnets.Select(v =>
+        {
+            var zone = _sdnZones.FirstOrDefault(z => z.Zone == v.Zone);
+            var nodes = string.IsNullOrEmpty(zone?.Nodes)
+                            ? (IReadOnlyList<string>)[.. _resources.Where(r => r.ResourceType == ClusterResourceType.Node).Select(r => r.Node)]
+                            : [.. zone.Nodes.Split(',').Select(s => s.Trim())];
+            return new NetworkDiagramBuilder.SdnVnetRow(
+                Vnet: v.Vnet ?? "",
+                Zone: v.Zone ?? "",
+                ZoneType: zone?.Type ?? "simple",
+                ZoneBridge: zone?.Bridge,
+                Tag: v.Tag,
+                Alias: v.Alias,
+                Nodes: nodes);
+        })];
 
         _writer.Links[LinkKey.Storages] = "Storages";
         _writer.Links[LinkKey.ListNodes] = "Nodes";
@@ -309,6 +336,7 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
     {
         NetworkDiagramSvg = NetworkDiagramBuilder.BuildSvg(
             _pendingNodeNetworkRows.Select(r => new NetworkDiagramBuilder.NodeNetworkRow(r.Node, r.Network)),
+            _sdnRows,
             _pendingNetworkRows.Select(r => new NetworkDiagramBuilder.VmNetworkRow(r.VmId, r.Name, r.Node, r.Type, r.Status, r.Hostname, r.Network, r.IsInternal)),
             _storageConfigs,
             new NetworkDiagramBuilder.DiagramInfo(info.ApplicationName, info.ApplicationUrl, info.ApplicationVersion));


### PR DESCRIPTION
## Summary

Two related fixes that ship together because both depend on the upstream SDK bump (`Corsinvest.ProxmoxVE.Api.Shared` / `Api.Extension`).

### Fix #37 — `efidisk0` / `tpmstate0` missing from the Disks sheet

The SDK used to consume those two keys into typed properties (`VmConfigQemu.Efidisk0` / `.Tpmstate0`), which removed them from the generic `ExtensionData` dictionary the disk-parser iterates on. Result: VMs with an EFI disk or TPM state ended up with no row in the Disks sheet for those volumes.

Fix lives upstream — the two typed properties have been dropped, the keys now flow through the regular regex match in `VmConfig.ReadDisks()` alongside `scsi0` / `virtio0` / etc. On the report side, the only follow-up is removing the per-VM detail \"TPM State\" key/value row, which pointed at the now-removed `Tpmstate0` property and would have shown the raw config string anyway.

### Fix #36 — VMs attached to SDN vnets disappearing from the network diagram

When a VM's NIC pointed at a bridge that lives at datacenter SDN level (e.g. `OLDVMS`) but wasn't materialised in the node's `/etc/network/interfaces`, the diagram builder had no bridge to draw the VM under, and the VM was silently dropped. In Excel it was still listed because the main VM table doesn't depend on network rows.

The network diagram builder now accepts an explicit list of SDN vnets and synthesises a bridge per node where the zone is active, deduped against host bridges. The fix needs the new `BuildSvg(hostNets, sdnVnets, vmNets, storages, info)` signature from the SDK.

## What's in here

### Engine
- [`ReportEngine.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs) — `LoadResourcesAsync` now fetches `_storageConfigs`, `_sdnVnets`, `_sdnZones` in parallel. A flattened `_sdnRows` (`SdnVnetRow` list with zone metadata + materialised-on-nodes expansion) is built once for the diagram and the Network sheet.
- [`ReportEngine.Cluster.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.Cluster.cs) — keeps the existing SDN tables but now consumes the cached `_sdnVnets` / `_sdnZones` (removed duplicate `Cluster.Sdn.Vnets.GetAsync()` / `Zones.GetAsync()` calls).
- [`ReportEngine.Network.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.Network.cs) — new \"SDN Vnets\" table between \"Nodes Networks\" and \"VM Networks\".
- [`ReportEngine.Vm.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs) — drop the \"TPM State\" row (#37 follow-up).
- `BuildAndStoreNetworkDiagramSvg` passes `_sdnRows` to the new `BuildSvg` overload.

### Docs / metadata
- [`CHANGELOG.md`](CHANGELOG.md) — 2.2.1 entry with both fixes.
- [`Directory.Build.props`](Directory.Build.props) — bump to `2.2.1`.
- [`Directory.Packages.props`](Directory.Packages.props) — SDK bump.

## Sample behaviour after the fix

A VM `vm-101` whose config has `net0: bridge=OLDVMS` now:
- still appears in the VMs sheet ✅ (already worked)
- appears in the Network sheet with `Bridge=OLDVMS` ✅ (already worked)
- has a row in the new **SDN Vnets** table of the Network sheet that explains what `OLDVMS` is (zone, type, nodes) ✅ (new)
- is drawn under an `OLDVMS` bridge box in the SVG diagram on every node where the zone is active ✅ (new — was missing)

A VM with `efidisk0: local-lvm:vm-100-disk-2,size=4M,efitype=4m` now:
- appears in the Disks sheet with `Id = efidisk0` and the same columns as the other disks ✅ (was missing)

## Test plan

- [ ] `cv4pve-report ... export` on a cluster with SDN — `OLDVMS`-style vnets appear in the Network sheet *SDN Vnets* table and in the SVG.
- [ ] `cv4pve-report ... export` on a cluster with vnets named the same as physical bridges (Simple zone wrapping `vmbr1`) — no duplicates in the diagram, the bridge is drawn once.
- [ ] VM with `efidisk0` and `tpmstate0` — both appear in the Disks sheet.
- [ ] VM detail sheet — no \"TPM State\" key/value row (replaced by the disk row in Disks sheet).
- [ ] Cluster sheet — SDN tables (Zones / Vnets / Subnets) still populated.
- [ ] `dotnet build` clean on net8 / net9 / net10.
- [ ] `dotnet format --verify-no-changes` clean.

Closes #37, #36.