### PR TITLE
feat: include CD-ROM and cloud-init drives in the Disks sheet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.17" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.17" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.18" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.18" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs
@@ -121,7 +121,7 @@ public partial class ReportEngine
 
             if (d.Config != null)
             {
-                AppendDiskRows(item, d.Config.Disks);
+                AppendDiskRows(item, d.Config.DisksAll);
 
                 if (settings.Guest.Detail.Enabled)
                 {

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Disks.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Disks.cs
@@ -36,6 +36,7 @@ public partial class ReportEngine
                 VmName = entry.Vm.Name,
                 VmType = entry.Vm.Type,
                 VmStatus = entry.Vm.Status,
+                a.Kind,
                 a.Id,
                 a.Storage,
                 StorageType = storageRes?.PluginType,

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs
@@ -247,7 +247,7 @@ public partial class ReportEngine
                     AppendPartitionRows(item, d.FsInfo);
                 }
 
-                AppendDiskRows(item, d.Config.Disks);
+                AppendDiskRows(item, d.Config.DisksAll);
 
                 if (settings.Guest.Detail.Enabled)
                 {


### PR DESCRIPTION
## Summary

The Disks sheet used to list only the block-storage drives (`scsi0`, `virtio0`, `efidisk0`, `tpmstate0`, …). Other guest drives configured on the VM — CD-ROM images and cloud-init disks — were silently dropped because the SDK exposed them under a separate code path.

This PR feeds the Disks sheet from the new `VmConfig.DisksAll` (introduced in SDK 9.1.18), which unifies regular disks, CD-ROMs and cloud-init drives into one collection. Each row is tagged with a `Kind` discriminator so the entry type is obvious at a glance.

## What's in here

- [`Directory.Packages.props`](Directory.Packages.props) — SDK bump `9.1.17` → `9.1.18` for `DisksAll` + `Kind`.
- [`ReportEngine.Vm.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.Vm.cs) — `AppendDiskRows(item, d.Config.Disks)` → `…DisksAll`.
- [`ReportEngine.Container.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.Container.cs) — same swap for LXC.
- [`ReportEngine.Disks.cs`](src/Corsinvest.ProxmoxVE.Report/ReportEngine.Disks.cs) — new `Kind` column, placed right before `Id` so the row type is the first thing visible.

## Behaviour change

A VM with the following config (typical Windows install in-progress):

```
scsi0:     local-lvm:vm-100-disk-0,size=80G
ide2:      local:iso/Win11_24H2.iso,media=cdrom
ide0:      local:cloudinit
efidisk0:  local-lvm:vm-100-disk-1,size=4M
```

Before:

| Kind | Id | Storage | … |
|---|---|---|---|
| – | scsi0 | local-lvm | … |
| – | efidisk0 | local-lvm | … |

After:

| Kind | Id | Storage | … |
|---|---|---|---|
| Disk | scsi0 | local-lvm | … |
| CDRom | ide2 | local | … |
| CloudInit | ide0 | local | … |
| Disk | efidisk0 | local-lvm | … |

## Release plan

This change rides with the upcoming **2.3.0** release (alongside the new JSON output format currently in development on `feat/json-output`). No tag from this PR — `master` accumulates 2.3.0 changes until we cut the release.

## Test plan

- [ ] `cv4pve-report ... export` on a cluster with VMs that have ISO/CD-ROM and cloud-init drives — they appear in the Disks sheet with the right `Kind`.
- [ ] VMs without CD-ROM / cloud-init — Disks sheet unchanged.
- [ ] `dotnet build` clean on net8/9/10.
- [ ] `dotnet format --verify-no-changes` clean.