### PR TITLE
feat: JSON output format (--format Json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Report Tool for Proxmox VE (Made in Italy)
 [![WinGet](https://img.shields.io/winget/v/Corsinvest.cv4pve.report?style=flat-square&logo=windows)](https://winstall.app/apps/Corsinvest.cv4pve.report)
 [![AUR](https://img.shields.io/aur/version/cv4pve-report?style=flat-square&logo=archlinux)](https://aur.archlinux.org/packages/cv4pve-report)
 
-> **The RVTools for Proxmox VE** — exports your entire Proxmox VE infrastructure as a single [Excel workbook](#excel-output---format-xlsx-default) **or** a [self-contained HTML site](#html-output---format-html), plus a network topology diagram (SVG).
+> **The RVTools for Proxmox VE** — exports your entire Proxmox VE infrastructure as a single [Excel workbook](#excel-output---format-xlsx-default), a [self-contained HTML site](#html-output---format-html) **or** a [multi-file JSON dataset](#json-output---format-json), plus a network topology diagram (SVG).
 
 **Fully navigable** — every node, VM and storage in the overview tables is a hyperlink to its dedicated detail page. Click and you're there.
 
@@ -39,7 +39,7 @@ RVTools is a pure inventory tool for VMware — it exports infrastructure data t
 |---|---------|:-----------------:|:-----------:|
 | **Platform** | VMware vSphere | Proxmox VE | Proxmox VE |
 | **Purpose** | Inventory & reporting | **Inventory & reporting** | **Diagnostics & health checks** |
-| **Output** | Excel | [Excel](#excel-output---format-xlsx-default) **or** [static HTML site](#html-output---format-html), plus [SVG network diagram](docs/network-diagram.md) | Text / HTML / JSON / Markdown / Excel |
+| **Output** | Excel | [Excel](#excel-output---format-xlsx-default), [static HTML site](#html-output---format-html) **or** [multi-file JSON](#json-output---format-json), plus [SVG network diagram](docs/network-diagram.md) | Text / HTML / JSON / Markdown / Excel |
 
 ### Capabilities
 
@@ -97,15 +97,16 @@ Pick the output format that fits your workflow:
 ```bash
 ./cv4pve-report ... export                  # Excel (default)
 ./cv4pve-report ... export --format Html    # HTML zipped site
+./cv4pve-report ... export --format Json    # JSON zipped dataset
 ```
 
-With `--output` / `-o` you choose the output path. **All formats now produce a single `.zip`** — extract it to access the files inside (a `.xlsx` for Excel, an `index.html` plus assets for HTML). The network topology SVG (`network-diagram.svg`) is bundled in the same zip. If the path you pass doesn't end in `.zip`, the extension is appended automatically.
+With `--output` / `-o` you choose the output path. **All formats now produce a single `.zip`** — extract it to access the files inside (a `.xlsx` for Excel, an `index.html` plus assets for HTML, one JSON per section for JSON). The network topology SVG (`network-diagram.svg`) is bundled in the same zip. If the path you pass doesn't end in `.zip`, the extension is appended automatically.
 
 ---
 
 ## Output Formats
 
-Both formats expose **the same data** using the same logical layout — one section per topic (Cluster, Nodes, VMs, Containers, Storages, …) plus per-resource detail (one per node, VM and container). Only the rendering differs: a sheet per section in Excel, a page per section in HTML. Pick the one that matches what you need to do with the report — each format has its own full reference under [`docs/`](docs/).
+All three formats expose **the same data** using the same logical layout — one section per topic (Cluster, Nodes, VMs, Containers, Storages, …) plus per-resource detail (one per node, VM and container). Only the rendering differs: a sheet per section in Excel, a page per section in HTML, a file per section in JSON. Pick the one that matches what you need to do with the report — each format has its own full reference under [`docs/`](docs/).
 
 ### Excel output `(--format Xlsx, default)`
 
@@ -140,6 +141,22 @@ For sharing on a wiki, ticket system or with non-technical stakeholders. Extract
 - **Network topology SVG** — bundled inside the zip and accessible from the sidebar — [guide](docs/network-diagram.md)
 
 > Full reference: **[HTML format guide](docs/format-html.md)** — page layout, sidebar behaviour, theme, export button and lazy-loading for large clusters.
+
+### JSON output `(--format Json)`
+
+```
+Report_20260506_120000.zip    ← multi-file JSON dataset (extract and parse with jq, Power BI, scripts, …)
+```
+
+For automation, scripting and integrations. Extract the zip and consume the files with `jq`, Python, PowerShell, Power BI, or any tool that reads JSON.
+
+- **One file per section** — `cluster.json`, `nodes.json`, `vms.json`, `storages.json`, … plus `nodes/<name>.json`, `vms/<id>.json` and `containers/<id>.json` for per-resource detail; same logical layout as the Excel sheets and HTML pages
+- **Stable file paths** — perfect for snapshot diffs: store the extracted zip in git and `diff -r` two snapshots to see exactly which VMs/nodes/storages changed
+- **Pipeline-friendly** — small file size (≈ a few MB even on 2700+ VM clusters; gzip compresses heavily), easy to ingest from CI / cron / monitoring jobs
+- **Rich metadata** — `metadata.json` carries the schema version, timestamp, application info and per-section generation stats
+- **Network topology SVG** — bundled as `network-diagram.svg` inside the zip
+
+> Full reference: **[JSON format guide](docs/format-json.md)** — file layout, schema, naming conventions and `jq` examples for common tasks.
 
 ---
 

--- a/docs/format-json.md
+++ b/docs/format-json.md
@@ -2,10 +2,6 @@
 
 `--format Json` produces a multi-file zipped JSON dataset. Extract the zip and consume the files with `jq`, Python, PowerShell, Power BI or any JSON-aware tool.
 
-```
-Report_20260506_120000.zip    ← multi-file JSON dataset
-```
-
 ---
 
 ## File layout inside the zip
@@ -13,6 +9,7 @@ Report_20260506_120000.zip    ← multi-file JSON dataset
 ```
 Report_20260506_120000.zip
 ├── metadata.json              ← report-wide info (schema version, timestamp, filters, generation stats)
+├── issues.json                ← only present when at least one collection failure was recorded
 ├── network-diagram.svg        ← network topology diagram (raw SVG)
 │
 ├── cluster.json
@@ -44,34 +41,84 @@ Report_20260506_120000.zip
 └── syslog.json
 ```
 
-Same logical layout as the [Excel sheets](format-xlsx.md) and [HTML pages](format-html.md) — only the rendering differs.
+---
+
+## Sections
+
+Files are written in this order. Conditional files (`if …`) are only present when the matching setting is enabled or when the underlying data exists.
+
+| # | File | Description | Condition |
+|---|------|-------------|-----------|
+| 1 | **metadata.json** | Report-wide info: schema version, timestamp, filters, per-section generation log | always |
+| 2 | **issues.json** | Diagnostics for collection failures — see [Issues](#issues) below | only when failures recorded |
+| 3 | **cluster.json** | Cluster-wide configuration and security (users, ACL, firewall options, backup jobs, HA, SDN, pools, hardware mappings) | `Cluster.Include` |
+| 4 | **nodes.json** + **nodes/`<name>`.json** | Node overview list + per-node detail file | always |
+| 5 | **vms.json** + **vms/`<id>`.json** | VM overview list + per-VM detail file | always |
+| 6 | **containers.json** + **containers/`<id>`.json** | Container overview list + per-CT detail file | always |
+| 7 | **network.json** | Node interfaces + VM/CT NICs (MAC, bridge, VLAN, IPs, model) | always |
+| 8 | **storages.json** | Storage list with size, usage, type | always |
+| 9 | **storage-content.json** | Storage files/images with size and VM ID links | `Storage.IncludeContent` |
+| 10 | **backups.json** | Backup files across all storages | `Storage.IncludeBackups` |
+| 11 | **disks.json** | Global VM/CT disk inventory | `Guest.IncludeDisks` |
+| 12 | **partitions.json** | Guest disk partitions via QEMU agent | `Guest.IncludePartitions` |
+| 13 | **snapshots.json** | Global snapshot inventory across all VMs/CTs | `Guest.IncludeSnapshots` |
+| 14 | **firewall.json** | Cluster + node + VM/CT firewall rules, aliases, IP sets | `Firewall.Enabled` |
+| 15 | **replication.json** | Replication job status across all nodes | `Node.IncludeReplication` |
+| 16 | **rrd-nodes.json** | Historical performance metrics per node | `Node.RrdData.Enabled` |
+| 17 | **rrd-storages.json** | Historical performance metrics per storage | `Storage.RrdData.Enabled` |
+| 18 | **rrd-guests.json** | Historical performance metrics per VM/CT | `Guest.RrdData.Enabled` |
+| 19 | **syslog.json** | Parsed systemd journal across all nodes | `Node.Syslog.Enabled` |
+| 20 | **cluster-log.json** | Cluster event log | `Cluster.Log.Enabled` |
+| 21 | **cluster-tasks.json** | Recent tasks across the cluster | `Cluster.IncludeTasks` |
+
+> The contents of each file (which keys, which values) are emitted by the engine and identical across formats — see [`docs/settings.md`](settings.md) for the toggles.
 
 ---
 
-## File shapes
+## Issues
 
-### Overview files (single table)
+When one or more Proxmox API calls fail during collection (a corrupt RRD file, a `500` from a node, missing permissions on a sub-resource, …), an extra `issues.json` file is emitted. On a healthy cluster the file is absent.
 
-`vms.json`, `nodes.json`, `containers.json`, `storages.json`, `disks.json`, `snapshots.json`, `partitions.json`, `network.json`, `replication.json`, `cluster-log.json`, `cluster-tasks.json`, `syslog.json`, `rrd-*.json`, `backups.json`, `storage-content.json`:
+```json
+{
+  "issues": [
+    {
+      "severity": "Warning",
+      "section": "RRD Storage",
+      "message": "500 Internal Server Error — got wrong time resolution (60 != 1800) — GET /nodes/orion/storage/local-ceph/rrddata",
+      "timestamp": "2026-05-11T12:30:14.1234567Z",
+      "linkKey": "node:orion"
+    }
+  ]
+}
+```
+
+| Field | Content |
+|---|---|
+| `severity` | `Warning` (default) — `501 Not Implemented` is silent and never appears here. |
+| `section` | The logical section where the failure happened (e.g. `RRD Storage`, `Firewall Log`, `Cluster`). |
+| `message` | Diagnostic line built from the Proxmox response: HTTP status, the API error body and the failing endpoint, joined with `—`. |
+| `timestamp` | ISO-8601 UTC. |
+| `linkKey` | Opaque key pointing to the relevant resource: `vm:<id>`, `node:<name>`, `section:<name>`. Useful for cross-referencing other JSON files. |
+
+CI snapshots can fail/warn the build by checking `jq '.issues | length' issues.json` or `jq '[.issues[] | select(.severity == "Error")] | length'`.
+
+---
+
+## JSON-specific behaviour
+
+### File shapes
+
+**Overview files** — `vms.json`, `nodes.json`, `containers.json`, `storages.json`, `disks.json`, `snapshots.json`, `partitions.json`, `network.json`, `replication.json`, `cluster-log.json`, `cluster-tasks.json`, `syslog.json`, `rrd-*.json`, `backups.json`, `storage-content.json` are flat arrays of row objects:
 
 ```json
 [
-  {
-    "node": "cc01",
-    "vmId": 100,
-    "name": "Bookstack",
-    "status": "running",
-    ...
-  },
+  { "node": "cc01", "vmId": 100, "name": "Bookstack", "status": "running", "...": "..." },
   ...
 ]
 ```
 
-A flat array of row objects.
-
-### Detail files (multiple blocks)
-
-`vms/100.json`, `nodes/cc01.json`, `containers/200.json`, `cluster.json`, `firewall.json`:
+**Detail files** — `vms/100.json`, `nodes/cc01.json`, `containers/200.json`, `cluster.json`, `firewall.json` are objects keyed by block title; each value is either key/value pairs or an array of rows:
 
 ```json
 {
@@ -83,16 +130,14 @@ A flat array of row objects.
 }
 ```
 
-Each top-level key is a *block*; the value is either an object (key/value pairs) or an array of rows.
-
-### `metadata.json`
+**`metadata.json`** carries the report-wide info:
 
 ```json
 {
   "schemaVersion": 1,
   "generatedAt": "2026-05-08T17:28:51.8677072Z",
   "applicationName": "cv4pve-report",
-  "applicationVersion": "2.0.1",
+  "applicationVersion": "2.2.0",
   "applicationUrl": "https://github.com/Corsinvest/cv4pve-report",
   "filters": {
     "nodes": "@all",
@@ -107,17 +152,14 @@ Each top-level key is a *block*; the value is either an object (key/value pairs)
 }
 ```
 
-`schemaVersion` lets consumers adapt to future structural changes; `filters` mirrors what the Excel "Summary" sheet and the HTML cover page show; `sections` is a generation log useful for diagnostics.
+`schemaVersion` lets consumers adapt to future structural changes; `filters` mirrors the Excel `Summary` sheet and the HTML cover page; `sections` is a generation log useful for diagnostics.
 
----
-
-## Naming conventions
+### Naming conventions
 
 - **Property keys** are **camelCase** (`vmId`, `memorySizeGB`, `cpuUsagePct`).
 - **Common acronyms** keep their casing (`vmID`, `osType`, `agentOSInfo`, `sslCertificates`).
 - **`null`** values are omitted from the JSON to keep files compact.
-
-### Value types
+- **Boolean flags** coming from columns named `…Flag` are emitted as JSON booleans; their suffix is stripped (`isTemplateFlag` → `isTemplate`).
 
 | Kind | Key example | Value example | Notes |
 |---|---|---|---|
@@ -125,42 +167,30 @@ Each top-level key is a *block*; the value is either an object (key/value pairs)
 | Boolean | `isTemplate`, `enabled` | `true` / `false` | Real JSON booleans, not `"X"` / `""`. |
 | Number — count | `cpu`, `cores`, `count` | `8` | Integer or float, unit-less. |
 | Number — size | `memorySizeGB`, `rootFsMB` | `16.5` | The **unit is in the key suffix** (`GB` / `MB`); no auto-conversion. |
-| Number — percentage | `cpuUsagePct`, `memoryUsagePct` | `0.45` | Float **0–1**. Multiply by 100 if you want the "%" form. |
+| Number — percentage | `cpuUsagePct`, `memoryUsagePct` | `0.45` | Float **0–1**. Multiply by 100 for the "%" form. |
 | Datetime | `lastSync`, `startTime` | `"2026-05-10T14:30:00Z"` | ISO-8601, UTC. |
 | Date only | `expiry`, `validUntil` | `"2026-05-10"` | ISO-8601 date. |
 
----
+### `jq` recipes
 
-## `jq` examples
-
-**All running VMs**
 ```bash
+# All running VMs
 jq '.[] | select(.status == "running") | .name' vms.json
-```
 
-**VMs using more than 16 GB of memory**
-```bash
+# VMs using more than 16 GB of memory
 jq '.[] | select(.memorySizeGB > 16) | {id: .vmId, name: .name, memoryGB: .memorySizeGB}' vms.json
-```
 
-**Snapshot count per VM**
-```bash
+# Snapshot count per VM
 jq 'group_by(.vmId) | map({vmId: .[0].vmId, count: length})' snapshots.json
-```
 
-**SSL certificates expiring within 30 days**
-```bash
+# SSL certificates expiring within 30 days
 jq '.sslCertificates[] | select((.notAfter | fromdate) - now < 30*86400) | {file: .fileName, expires: .notAfter}' nodes/cc01.json
+
+# Pluck the network diagram out of the zip
+unzip -p Report_*.zip network-diagram.svg > diagram.svg
 ```
 
-**Pluck the network diagram out of the zip**
-```bash
-unzip -p report.zip network-diagram.svg > diagram.svg
-```
-
----
-
-## Snapshot diffs
+### Snapshot diffs
 
 Stable file paths (`vms/100.json`, `nodes/cc01.json`, …) make the JSON output ideal for snapshot comparison.
 
@@ -168,24 +198,18 @@ Stable file paths (`vms/100.json`, `nodes/cc01.json`, …) make the JSON output 
 # Take a snapshot every night
 cv4pve-report ... --format Json --output /backup/cv4pve/$(date +%F).zip
 
-# Later, compare two snapshots:
+# Compare two snapshots later
 unzip /backup/cv4pve/2026-04-01.zip -d old/
 unzip /backup/cv4pve/2026-05-01.zip -d new/
 diff -r old/ new/
-```
 
-The diff identifies exactly which VMs / nodes / storages changed, which were added, which were removed.
-
-For semantic, key-by-key diffs of a single resource:
-```bash
+# Semantic, key-by-key diff of a single resource
 diff <(jq -S . old/vms/100.json) <(jq -S . new/vms/100.json)
 ```
 
 `jq -S` sorts keys, so the diff highlights only real changes — not reordering noise.
 
----
-
-## Memory and size
+### Memory and size
 
 Each section is serialised straight into its zip entry without buffering, so peak memory stays bounded. Typical numbers:
 
@@ -197,10 +221,8 @@ Each section is serialised straight into its zip entry without buffering, so pea
 
 JSON compresses well; the zip is typically 5–10× smaller than the raw size.
 
----
-
-## Limitations / known caveats
+### Known caveats
 
 - Some fields are pre-formatted as multi-line strings (e.g. `tags`, `networks` summary in the overview lists) because the same data flows into Excel and HTML cells. Where this matters, prefer the corresponding *detail* file (e.g. `vms/100.json`), where most fields are exposed in their raw form.
 - Percentages are stored as floats (`0.45` for 45 %), not as strings with `%`.
-- Boolean flags coming from columns named `…Flag` are emitted as JSON booleans; their suffix is stripped (`isTemplateFlag` → `isTemplate`).
+- Network topology — bundled in the same zip as `network-diagram.svg`. See the [network diagram guide](network-diagram.md) for the legend and layout.

--- a/docs/format-json.md
+++ b/docs/format-json.md
@@ -11,7 +11,7 @@ Report_20260506_120000.zip    ← multi-file JSON dataset
 ## File layout inside the zip
 
 ```
-report.zip
+Report_20260506_120000.zip
 ├── metadata.json              ← report-wide info (schema version, timestamp, filters, generation stats)
 ├── network-diagram.svg        ← network topology diagram (raw SVG)
 │
@@ -113,14 +113,21 @@ Each top-level key is a *block*; the value is either an object (key/value pairs)
 
 ## Naming conventions
 
-- **Property keys** are **camelCase** (`vmId`, `memoryUsageGB`, `cpuUsagePct`).
-- **Common acronyms** keep their casing (`vmID`, `memoryGB`, `osType`, `agentOSInfo`).
-- **Timestamps** are ISO-8601 in UTC (`"2026-05-08T17:28:51Z"`).
-- **`null`** is used for genuinely missing values; null-valued keys are omitted from the JSON to keep the files compact.
-- **Suffix conventions** mirror the Excel column suffixes:
-  - `…Pct` → percentage as a float (e.g. `0.45` for 45 %)
-  - `…GB` / `…MB` → numeric size in the named unit
-  - `…Date` → date or datetime ISO-8601 string
+- **Property keys** are **camelCase** (`vmId`, `memorySizeGB`, `cpuUsagePct`).
+- **Common acronyms** keep their casing (`vmID`, `osType`, `agentOSInfo`, `sslCertificates`).
+- **`null`** values are omitted from the JSON to keep files compact.
+
+### Value types
+
+| Kind | Key example | Value example | Notes |
+|---|---|---|---|
+| Text | `name`, `node`, `status` | `"vm01"` | Plain string. |
+| Boolean | `isTemplate`, `enabled` | `true` / `false` | Real JSON booleans, not `"X"` / `""`. |
+| Number — count | `cpu`, `cores`, `count` | `8` | Integer or float, unit-less. |
+| Number — size | `memorySizeGB`, `rootFsMB` | `16.5` | The **unit is in the key suffix** (`GB` / `MB`); no auto-conversion. |
+| Number — percentage | `cpuUsagePct`, `memoryUsagePct` | `0.45` | Float **0–1**. Multiply by 100 if you want the "%" form. |
+| Datetime | `lastSync`, `startTime` | `"2026-05-10T14:30:00Z"` | ISO-8601, UTC. |
+| Date only | `expiry`, `validUntil` | `"2026-05-10"` | ISO-8601 date. |
 
 ---
 

--- a/docs/format-json.md
+++ b/docs/format-json.md
@@ -1,0 +1,199 @@
+# JSON format reference (`--format Json`)
+
+`--format Json` produces a multi-file zipped JSON dataset. Extract the zip and consume the files with `jq`, Python, PowerShell, Power BI or any JSON-aware tool.
+
+```
+Report_20260506_120000.zip    ← multi-file JSON dataset
+```
+
+---
+
+## File layout inside the zip
+
+```
+report.zip
+├── metadata.json              ← report-wide info (schema version, timestamp, filters, generation stats)
+├── network-diagram.svg        ← network topology diagram (raw SVG)
+│
+├── cluster.json
+├── cluster-log.json
+├── cluster-tasks.json
+├── nodes.json                 ← Nodes overview (compact list)
+├── nodes/
+│   ├── cc01.json              ← per-node detail
+│   └── cc02.json
+├── vms.json                   ← VMs overview (compact list)
+├── vms/
+│   ├── 100.json               ← per-VM detail
+│   └── 101.json
+├── containers.json
+├── containers/
+│   └── 200.json
+├── storages.json
+├── storage-content.json
+├── backups.json
+├── disks.json
+├── partitions.json
+├── snapshots.json
+├── network.json
+├── firewall.json
+├── replication.json
+├── rrd-nodes.json
+├── rrd-storages.json
+├── rrd-guests.json
+└── syslog.json
+```
+
+Same logical layout as the [Excel sheets](format-xlsx.md) and [HTML pages](format-html.md) — only the rendering differs.
+
+---
+
+## File shapes
+
+### Overview files (single table)
+
+`vms.json`, `nodes.json`, `containers.json`, `storages.json`, `disks.json`, `snapshots.json`, `partitions.json`, `network.json`, `replication.json`, `cluster-log.json`, `cluster-tasks.json`, `syslog.json`, `rrd-*.json`, `backups.json`, `storage-content.json`:
+
+```json
+[
+  {
+    "node": "cc01",
+    "vmId": 100,
+    "name": "Bookstack",
+    "status": "running",
+    ...
+  },
+  ...
+]
+```
+
+A flat array of row objects.
+
+### Detail files (multiple blocks)
+
+`vms/100.json`, `nodes/cc01.json`, `containers/200.json`, `cluster.json`, `firewall.json`:
+
+```json
+{
+  "info": { ... },             ← key/value summary block
+  "config": { ... },           ← key/value config block
+  "agentOSInfo": { ... },      ← optional QEMU-agent block
+  "firewallLogs": [ ... ],     ← optional table block
+  "tasks": [ ... ]             ← optional table block
+}
+```
+
+Each top-level key is a *block*; the value is either an object (key/value pairs) or an array of rows.
+
+### `metadata.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-08T17:28:51.8677072Z",
+  "applicationName": "cv4pve-report",
+  "applicationVersion": "2.0.1",
+  "applicationUrl": "https://github.com/Corsinvest/cv4pve-report",
+  "filters": {
+    "nodes": "@all",
+    "guests": "@all",
+    "guestRrd": { "timeFrame": "Day", "consolidation": "Average" }
+  },
+  "sections": [
+    { "name": "Cluster", "count": 1, "durationSeconds": 0.18 },
+    { "name": "Nodes",   "count": 25, "durationSeconds": 4.69 },
+    ...
+  ]
+}
+```
+
+`schemaVersion` lets consumers adapt to future structural changes; `filters` mirrors what the Excel "Summary" sheet and the HTML cover page show; `sections` is a generation log useful for diagnostics.
+
+---
+
+## Naming conventions
+
+- **Property keys** are **camelCase** (`vmId`, `memoryUsageGB`, `cpuUsagePct`).
+- **Common acronyms** keep their casing (`vmID`, `memoryGB`, `osType`, `agentOSInfo`).
+- **Timestamps** are ISO-8601 in UTC (`"2026-05-08T17:28:51Z"`).
+- **`null`** is used for genuinely missing values; null-valued keys are omitted from the JSON to keep the files compact.
+- **Suffix conventions** mirror the Excel column suffixes:
+  - `…Pct` → percentage as a float (e.g. `0.45` for 45 %)
+  - `…GB` / `…MB` → numeric size in the named unit
+  - `…Date` → date or datetime ISO-8601 string
+
+---
+
+## `jq` examples
+
+**All running VMs**
+```bash
+jq '.[] | select(.status == "running") | .name' vms.json
+```
+
+**VMs using more than 16 GB of memory**
+```bash
+jq '.[] | select(.memorySizeGB > 16) | {id: .vmId, name: .name, memoryGB: .memorySizeGB}' vms.json
+```
+
+**Snapshot count per VM**
+```bash
+jq 'group_by(.vmId) | map({vmId: .[0].vmId, count: length})' snapshots.json
+```
+
+**SSL certificates expiring within 30 days**
+```bash
+jq '.sslCertificates[] | select((.notAfter | fromdate) - now < 30*86400) | {file: .fileName, expires: .notAfter}' nodes/cc01.json
+```
+
+**Pluck the network diagram out of the zip**
+```bash
+unzip -p report.zip network-diagram.svg > diagram.svg
+```
+
+---
+
+## Snapshot diffs
+
+Stable file paths (`vms/100.json`, `nodes/cc01.json`, …) make the JSON output ideal for snapshot comparison.
+
+```bash
+# Take a snapshot every night
+cv4pve-report ... --format Json --output /backup/cv4pve/$(date +%F).zip
+
+# Later, compare two snapshots:
+unzip /backup/cv4pve/2026-04-01.zip -d old/
+unzip /backup/cv4pve/2026-05-01.zip -d new/
+diff -r old/ new/
+```
+
+The diff identifies exactly which VMs / nodes / storages changed, which were added, which were removed.
+
+For semantic, key-by-key diffs of a single resource:
+```bash
+diff <(jq -S . old/vms/100.json) <(jq -S . new/vms/100.json)
+```
+
+`jq -S` sorts keys, so the diff highlights only real changes — not reordering noise.
+
+---
+
+## Memory and size
+
+Each section is serialised straight into its zip entry without buffering, so peak memory stays bounded. Typical numbers:
+
+| Cluster size | RRD off | RRD on |
+|---|---|---|
+| Small (5 nodes / 20 VMs) | < 200 KB raw | < 1 MB raw |
+| Medium (10 nodes / 200 VMs) | ~ 1.5 MB raw | ~ 10 MB raw |
+| Large (25 nodes / 2700 VMs) | ~ 5 MB raw | ~ 60 MB raw |
+
+JSON compresses well; the zip is typically 5–10× smaller than the raw size.
+
+---
+
+## Limitations / known caveats
+
+- Some fields are pre-formatted as multi-line strings (e.g. `tags`, `networks` summary in the overview lists) because the same data flows into Excel and HTML cells. Where this matters, prefer the corresponding *detail* file (e.g. `vms/100.json`), where most fields are exposed in their raw form.
+- Percentages are stored as floats (`0.45` for 45 %), not as strings with `%`.
+- Boolean flags coming from columns named `…Flag` are emitted as JSON booleans; their suffix is stripped (`isTemplateFlag` → `isTemplate`).

--- a/docs/format-json.md
+++ b/docs/format-json.md
@@ -36,7 +36,7 @@ Report_20260506_120000.zip
 ├── firewall.json
 ├── replication.json
 ├── rrd-nodes.json
-├── rrd-storages.json
+├── rrd-storage.json
 ├── rrd-guests.json
 └── syslog.json
 ```
@@ -65,7 +65,7 @@ Files are written in this order. Conditional files (`if …`) are only present w
 | 14 | **firewall.json** | Cluster + node + VM/CT firewall rules, aliases, IP sets | `Firewall.Enabled` |
 | 15 | **replication.json** | Replication job status across all nodes | `Node.IncludeReplication` |
 | 16 | **rrd-nodes.json** | Historical performance metrics per node | `Node.RrdData.Enabled` |
-| 17 | **rrd-storages.json** | Historical performance metrics per storage | `Storage.RrdData.Enabled` |
+| 17 | **rrd-storage.json** | Historical performance metrics per storage | `Storage.RrdData.Enabled` |
 | 18 | **rrd-guests.json** | Historical performance metrics per VM/CT | `Guest.RrdData.Enabled` |
 | 19 | **syslog.json** | Parsed systemd journal across all nodes | `Node.Syslog.Enabled` |
 | 20 | **cluster-log.json** | Cluster event log | `Cluster.Log.Enabled` |

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
@@ -167,6 +167,7 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
         {
             ReportFormat.Xlsx => new Writers.Xlsx.XlsxReportWriter(info),
             ReportFormat.Html => new Writers.Html.HtmlReportWriter(info),
+            ReportFormat.Json => new Writers.Json.JsonReportWriter(info),
             _ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
         };
 

--- a/src/Corsinvest.ProxmoxVE.Report/ReportFormat.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportFormat.cs
@@ -15,4 +15,7 @@ public enum ReportFormat
 
     /// <summary>Static HTML site (index.html + per-section pages), packaged as a .zip.</summary>
     Html,
+
+    /// <summary>Multi-file JSON (one file per section + per-resource detail files), packaged as a .zip.</summary>
+    Json,
 }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonKey.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonKey.cs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Text;
+
+namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
+
+/// <summary>
+/// Helpers for turning human-readable display strings (as authored for Excel/HTML
+/// rendering) into JSON-friendly identifier keys.
+/// </summary>
+internal static class JsonKey
+{
+    /// <summary>
+    /// Translate a display string into a camelCase JSON key. Examples:
+    ///   "Services"          → "services"
+    ///   "SSL Certificates"  → "sslCertificates"
+    ///   "Agent OS Info"     → "agentOSInfo"
+    ///   "VM ID"             → "vmID"
+    ///   "CPU Usage %"       → "cpuUsage"
+    ///   "On Boot"           → "onBoot"
+    ///   "/etc/hosts"        → "etcHosts"
+    /// Symbols (% / parentheses / dashes / slashes) are dropped; the first word is
+    /// lowercased; subsequent words have their first letter uppercased while the
+    /// rest of each word is preserved (so common acronyms like ID/GB/MB/SSL/OS
+    /// keep their casing).
+    /// </summary>
+    public static string FromDisplay(string display)
+    {
+        if (string.IsNullOrEmpty(display)) { return display; }
+
+        var normalised = display.Replace("%", " ")
+                                .Replace("(", " ")
+                                .Replace(")", " ")
+                                .Replace("/", " ")
+                                .Replace("-", " ");
+
+        var words = normalised.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (words.Length == 0) { return display; }
+
+        var sb = new StringBuilder();
+        sb.Append(words[0].ToLowerInvariant());
+        for (var i = 1; i < words.Length; i++)
+        {
+            sb.Append(char.ToUpperInvariant(words[i][0]));
+            if (words[i].Length > 1) { sb.Append(words[i][1..]); }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Property-name → JSON key. The engine already authored property names in
+    /// PascalCase / camelCase (e.g. "VmId", "memoryUsageGB"), so the rules here
+    /// are simpler than for display strings: only the first character is folded
+    /// to lower-case.
+    /// </summary>
+    public static string FromPropertyName(string name)
+    {
+        if (string.IsNullOrEmpty(name) || char.IsLower(name[0])) { return name; }
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.Metadata.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.Metadata.cs
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
+
+internal sealed partial class JsonReportWriter
+{
+    /// <summary>
+    /// Builds the <c>metadata.json</c> payload — the JSON equivalent of the
+    /// XLSX "Summary" sheet and the HTML <c>index.html</c> cover page. Carries
+    /// the schema version, generation timestamp, application info, the same
+    /// subset of settings the Excel/HTML covers expose (node/guest filters and
+    /// RRD timeframes when enabled) and the per-section generation stats.
+    /// </summary>
+    private object BuildMetadata()
+        => new
+        {
+            schemaVersion = 1,
+            generatedAt = _generatedAt.ToString("O"),
+            applicationName = _info.ApplicationName,
+            applicationVersion = _info.ApplicationVersion,
+            applicationUrl = _info.ApplicationUrl,
+            filters = _settings is null ? null : new
+            {
+                nodes = _settings.Node.Names,
+                guests = _settings.Guest.Ids,
+                nodeRrd = _settings.Node.RrdData.Enabled
+                            ? new
+                            {
+                                timeFrame = _settings.Node.RrdData.TimeFrame.ToString(),
+                                consolidation = _settings.Node.RrdData.Consolidation.ToString(),
+                            }
+                            : null,
+                guestRrd = _settings.Guest.RrdData.Enabled
+                            ? new
+                            {
+                                timeFrame = _settings.Guest.RrdData.TimeFrame.ToString(),
+                                consolidation = _settings.Guest.RrdData.Consolidation.ToString(),
+                            }
+                            : null,
+                storageRrd = _settings.Storage.RrdData.Enabled
+                            ? new
+                            {
+                                timeFrame = _settings.Storage.RrdData.TimeFrame.ToString(),
+                                consolidation = _settings.Storage.RrdData.Consolidation.ToString(),
+                            }
+                            : null,
+            },
+            sections = _stats.Select(s => new
+            {
+                name = s.Name,
+                count = s.Count,
+                durationSeconds = s.Duration.TotalSeconds,
+            }),
+        };
+}

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
@@ -11,13 +11,6 @@ using System.Text.Json.Serialization;
 
 namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
 
-/// <summary>
-/// JSON report writer. Captures every section the engine emits and materialises
-/// the report as a multi-file zip with one file per section plus per-resource
-/// detail files for nodes / VMs / containers — see docs/json-format.md for the
-/// schema. Each section is serialised straight into its zip entry (no intermediate
-/// string), so the peak memory footprint stays bounded even on very large clusters.
-/// </summary>
 internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
 {
     private static readonly JsonSerializerOptions JsonOpts = new()
@@ -25,6 +18,7 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        Converters = { new JsonStringEnumConverter() },
     };
 
     private readonly List<JsonSectionWriter> _sections = [];
@@ -41,9 +35,6 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
     public ISectionWriter AddSection(SectionId id)
     {
         Links[id.Key] = id.Key;
-
-        // Auto-register the canonical section:* key so cross-section references resolve
-        // (mirrors the Xlsx/Html writers).
         if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = id.Key; }
 
         var section = new JsonSectionWriter(id.Key);
@@ -70,10 +61,7 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
             await WriteJsonEntryAsync(zip, path, payload);
         }
 
-        if (_networkDiagramSvg is { Length: > 0 })
-        {
-            WriteTextEntry(zip, "network-diagram.svg", _networkDiagramSvg);
-        }
+        await ZipHelpers.WriteNetworkDiagramAsync(zip, _networkDiagramSvg);
     }
 
     public void Dispose() { }
@@ -118,12 +106,6 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
         return sb.ToString();
     }
 
-    /// <summary>
-    /// Build the payload for a section. A section that contains a single Table block
-    /// (e.g. "Nodes" overview) collapses to the array directly. A section with multiple
-    /// blocks (e.g. "Cluster" with users / tokens / groups / …, or a per-VM detail with
-    /// keyValue + table mixes) is emitted as an object keyed by block title.
-    /// </summary>
     private static object? SectionPayload(JsonSectionWriter section)
     {
         if (section.Blocks.Count == 0) { return new Dictionary<string, object?>(); }
@@ -135,12 +117,19 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
         }
 
         var result = new Dictionary<string, object?>();
-        foreach (var block in section.Blocks)
+        for (var i = 0; i < section.Blocks.Count; i++)
         {
+            var block = section.Blocks[i];
             switch (block)
             {
                 case JsonBlock.KeyValue kv:
-                    result[JsonKey.FromDisplay(kv.Title)] = kv.Items;
+                    // The first KeyValue of a multi-block section is the page header
+                    // (display label = VM id+name, node hostname, "Cluster", …). Its
+                    // title is unstable and duplicates the file path; expose it under
+                    // the fixed "info" key so consumers can navigate predictably.
+                    result[i == 0
+                            ? "info"
+                            : JsonKey.FromDisplay(kv.Title)] = kv.Items;
                     break;
 
                 case JsonBlock.Table tbl:
@@ -151,24 +140,10 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
         return result;
     }
 
-    /// <summary>
-    /// Serialise <paramref name="payload"/> straight into a new zip entry,
-    /// without buffering the JSON as an intermediate string. This keeps the
-    /// peak memory bounded even when a single section serialises to tens of MB
-    /// (e.g. RRD data on large clusters).
-    /// </summary>
     private static async Task WriteJsonEntryAsync(ZipArchive zip, string path, object? payload)
     {
         var entry = zip.CreateEntry(path, CompressionLevel.Optimal);
-        using var stream = entry.Open();
+        await using var stream = entry.Open();
         await JsonSerializer.SerializeAsync(stream, payload, JsonOpts);
-    }
-
-    private static void WriteTextEntry(ZipArchive zip, string path, string content)
-    {
-        var entry = zip.CreateEntry(path, CompressionLevel.Optimal);
-        using var stream = entry.Open();
-        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
-        writer.Write(content);
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
@@ -15,11 +15,10 @@ namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
 /// JSON report writer. Captures every section the engine emits and materialises
 /// the report as a multi-file zip with one file per section plus per-resource
 /// detail files for nodes / VMs / containers — see docs/json-format.md for the
-/// schema. Sections are accumulated in memory (not streamed); typical reports
-/// produce a handful of MB of JSON, well within memory budgets even on large
-/// clusters.
+/// schema. Each section is serialised straight into its zip entry (no intermediate
+/// string), so the peak memory footprint stays bounded even on very large clusters.
 /// </summary>
-internal sealed class JsonReportWriter : IReportWriter
+internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
 {
     private static readonly JsonSerializerOptions JsonOpts = new()
     {
@@ -28,54 +27,48 @@ internal sealed class JsonReportWriter : IReportWriter
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 
-    private readonly Dictionary<string, string> _links = [];
     private readonly List<JsonSectionWriter> _sections = [];
     private readonly DateTime _generatedAt = DateTime.UtcNow;
-    private string? _networkDiagramSvg;
-    private ReportInfo? _info;
+    private readonly ReportInfo _info = info;
+    private List<SectionStat> _stats = [];
     private Settings? _settings;
-    private List<SectionStat>? _stats;
+    private string? _networkDiagramSvg;
 
-    public IDictionary<string, string> Links => _links;
-
-    public void SetMetadata(ReportInfo info) => _info = info;
+    public Dictionary<string, string> Links { get; } = [];
 
     public void SetNetworkDiagram(string svg) => _networkDiagramSvg = svg;
 
     public ISectionWriter AddSection(SectionId id)
     {
-        _links[id.Key] = id.Key;
+        Links[id.Key] = id.Key;
         var section = new JsonSectionWriter(id.Key);
         _sections.Add(section);
         return section;
     }
 
-    public void WriteCoverPage(ReportInfo info, Settings settings, IEnumerable<SectionStat> stats)
+    public void WriteCoverPage(Settings settings, IEnumerable<SectionStat> stats)
     {
-        // The "cover" is metadata in JSON: stash inputs and emit metadata.json on save.
         _settings = settings;
-        _stats = stats.ToList();
+        _stats = [.. stats];
     }
 
-    public Task SaveAsync(Stream stream)
+    public async Task SaveAsync(Stream stream)
     {
         using var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
 
-        WriteEntry(zip, "metadata.json", BuildMetadata());
+        await WriteJsonEntryAsync(zip, "metadata.json", BuildMetadata());
 
         foreach (var section in _sections)
         {
             var path = JsonFileName(section.Name);
             var payload = SectionPayload(section);
-            WriteEntry(zip, path, Serialize(payload));
+            await WriteJsonEntryAsync(zip, path, payload);
         }
 
         if (_networkDiagramSvg is { Length: > 0 })
         {
-            WriteEntry(zip, "network-diagram.svg", _networkDiagramSvg);
+            WriteTextEntry(zip, "network-diagram.svg", _networkDiagramSvg);
         }
-
-        return Task.CompletedTask;
     }
 
     public void Dispose() { }
@@ -142,48 +135,35 @@ internal sealed class JsonReportWriter : IReportWriter
             switch (block)
             {
                 case JsonBlock.KeyValue kv:
-                    result[kv.Title] = kv.Items;
+                    result[JsonKey.FromDisplay(kv.Title)] = kv.Items;
                     break;
+
                 case JsonBlock.Table tbl:
-                    result[tbl.Title ?? "rows"] = tbl.Rows;
+                    result[tbl.Title is null ? "rows" : JsonKey.FromDisplay(tbl.Title)] = tbl.Rows;
                     break;
             }
         }
         return result;
     }
 
-    private string BuildMetadata()
-    {
-        var payload = new Dictionary<string, object?>
-        {
-            ["schemaVersion"] = 1,
-            ["generatedAt"] = _generatedAt.ToString("O"),
-            ["applicationName"] = _info?.ApplicationName,
-            ["applicationVersion"] = _info?.ApplicationVersion,
-            ["applicationUrl"] = _info?.ApplicationUrl,
-        };
-
-        if (_stats is { Count: > 0 })
-        {
-            payload["sections"] = _stats.Select(s => new Dictionary<string, object?>
-            {
-                ["name"] = s.Name,
-                ["count"] = s.Count,
-                ["durationSeconds"] = s.Duration.TotalSeconds,
-            }).ToList();
-        }
-
-        return Serialize(payload);
-    }
-
-    private static string Serialize(object? payload)
-        => JsonSerializer.Serialize(payload, JsonOpts);
-
-    private static void WriteEntry(ZipArchive zip, string path, string content)
+    /// <summary>
+    /// Serialise <paramref name="payload"/> straight into a new zip entry,
+    /// without buffering the JSON as an intermediate string. This keeps the
+    /// peak memory bounded even when a single section serialises to tens of MB
+    /// (e.g. RRD data on large clusters).
+    /// </summary>
+    private static async Task WriteJsonEntryAsync(ZipArchive zip, string path, object? payload)
     {
         var entry = zip.CreateEntry(path, CompressionLevel.Optimal);
         using var stream = entry.Open();
-        using var writer = new StreamWriter(stream, new System.Text.UTF8Encoding(false));
+        await JsonSerializer.SerializeAsync(stream, payload, JsonOpts);
+    }
+
+    private static void WriteTextEntry(ZipArchive zip, string path, string content)
+    {
+        var entry = zip.CreateEntry(path, CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
         writer.Write(content);
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.IO.Compression;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
+
+/// <summary>
+/// JSON report writer. Captures every section the engine emits and materialises
+/// the report as a multi-file zip with one file per section plus per-resource
+/// detail files for nodes / VMs / containers — see docs/json-format.md for the
+/// schema. Sections are accumulated in memory (not streamed); typical reports
+/// produce a handful of MB of JSON, well within memory budgets even on large
+/// clusters.
+/// </summary>
+internal sealed class JsonReportWriter : IReportWriter
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private readonly Dictionary<string, string> _links = [];
+    private readonly List<JsonSectionWriter> _sections = [];
+    private readonly DateTime _generatedAt = DateTime.UtcNow;
+    private string? _networkDiagramSvg;
+    private ReportInfo? _info;
+    private Settings? _settings;
+    private List<SectionStat>? _stats;
+
+    public IDictionary<string, string> Links => _links;
+
+    public void SetMetadata(ReportInfo info) => _info = info;
+
+    public void SetNetworkDiagram(string svg) => _networkDiagramSvg = svg;
+
+    public ISectionWriter AddSection(SectionId id)
+    {
+        _links[id.Key] = id.Key;
+        var section = new JsonSectionWriter(id.Key);
+        _sections.Add(section);
+        return section;
+    }
+
+    public void WriteCoverPage(ReportInfo info, Settings settings, IEnumerable<SectionStat> stats)
+    {
+        // The "cover" is metadata in JSON: stash inputs and emit metadata.json on save.
+        _settings = settings;
+        _stats = stats.ToList();
+    }
+
+    public Task SaveAsync(Stream stream)
+    {
+        using var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
+
+        WriteEntry(zip, "metadata.json", BuildMetadata());
+
+        foreach (var section in _sections)
+        {
+            var path = JsonFileName(section.Name);
+            var payload = SectionPayload(section);
+            WriteEntry(zip, path, Serialize(payload));
+        }
+
+        if (_networkDiagramSvg is { Length: > 0 })
+        {
+            WriteEntry(zip, "network-diagram.svg", _networkDiagramSvg);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public void Dispose() { }
+
+    /// <summary>
+    /// Translate a logical section name to its file path inside the zip:
+    ///   "Cluster"     -> "cluster.json"
+    ///   "Node cc01"   -> "nodes/cc01.json"
+    ///   "VM 100"      -> "vms/100.json"
+    ///   "CT 200"      -> "containers/200.json"
+    ///   "RRD Nodes"   -> "rrd-nodes.json"
+    /// </summary>
+    private static string JsonFileName(string sectionName)
+    {
+        if (sectionName.StartsWith("Node ", StringComparison.Ordinal))
+        {
+            return $"nodes/{Slug(sectionName["Node ".Length..])}.json";
+        }
+        else if (sectionName.StartsWith("VM ", StringComparison.Ordinal))
+        {
+            return $"vms/{Slug(sectionName["VM ".Length..])}.json";
+        }
+        else if (sectionName.StartsWith("CT ", StringComparison.Ordinal))
+        {
+            return $"containers/{Slug(sectionName["CT ".Length..])}.json";
+        }
+        else
+        {
+            return $"{Slug(sectionName)}.json";
+        }
+    }
+
+    private static string Slug(string name)
+    {
+        var sb = new StringBuilder(name.Length);
+        foreach (var c in name.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(c)) { sb.Append(c); }
+            else if (c == ' ' || c == '_' || c == '/' || c == '\\') { sb.Append('-'); }
+            else if (c == '.' || c == ':') { sb.Append('-'); }
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Build the payload for a section. A section that contains a single Table block
+    /// (e.g. "Nodes" overview) collapses to the array directly. A section with multiple
+    /// blocks (e.g. "Cluster" with users / tokens / groups / …, or a per-VM detail with
+    /// keyValue + table mixes) is emitted as an object keyed by block title.
+    /// </summary>
+    private static object? SectionPayload(JsonSectionWriter section)
+    {
+        if (section.Blocks.Count == 0) { return new Dictionary<string, object?>(); }
+
+        // Single table → return its rows directly (overview lists like vms.json / nodes.json).
+        if (section.Blocks.Count == 1 && section.Blocks[0] is JsonBlock.Table singleTable)
+        {
+            return singleTable.Rows;
+        }
+
+        var result = new Dictionary<string, object?>();
+        foreach (var block in section.Blocks)
+        {
+            switch (block)
+            {
+                case JsonBlock.KeyValue kv:
+                    result[kv.Title] = kv.Items;
+                    break;
+                case JsonBlock.Table tbl:
+                    result[tbl.Title ?? "rows"] = tbl.Rows;
+                    break;
+            }
+        }
+        return result;
+    }
+
+    private string BuildMetadata()
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["schemaVersion"] = 1,
+            ["generatedAt"] = _generatedAt.ToString("O"),
+            ["applicationName"] = _info?.ApplicationName,
+            ["applicationVersion"] = _info?.ApplicationVersion,
+            ["applicationUrl"] = _info?.ApplicationUrl,
+        };
+
+        if (_stats is { Count: > 0 })
+        {
+            payload["sections"] = _stats.Select(s => new Dictionary<string, object?>
+            {
+                ["name"] = s.Name,
+                ["count"] = s.Count,
+                ["durationSeconds"] = s.Duration.TotalSeconds,
+            }).ToList();
+        }
+
+        return Serialize(payload);
+    }
+
+    private static string Serialize(object? payload)
+        => JsonSerializer.Serialize(payload, JsonOpts);
+
+    private static void WriteEntry(ZipArchive zip, string path, string content)
+    {
+        var entry = zip.CreateEntry(path, CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        using var writer = new StreamWriter(stream, new System.Text.UTF8Encoding(false));
+        writer.Write(content);
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
@@ -41,6 +41,11 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
     public ISectionWriter AddSection(SectionId id)
     {
         Links[id.Key] = id.Key;
+
+        // Auto-register the canonical section:* key so cross-section references resolve
+        // (mirrors the Xlsx/Html writers).
+        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = id.Key; }
+
         var section = new JsonSectionWriter(id.Key);
         _sections.Add(section);
         return section;

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonSectionWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonSectionWriter.cs
@@ -58,9 +58,9 @@ internal sealed class JsonSectionWriter(string name) : ISectionWriter
 
         foreach (var p in props)
         {
-            var (suffix, _) = ColumnNameSuffix.Parse(p.Name);
+            var (kind, _) = ColumnConvention.Parse(p);
             var raw = p.GetValue(row);
-            var (key, value) = TransformByConvention(p.Name, raw, suffix);
+            var (key, value) = TransformByConvention(p.Name, raw, kind);
             result[JsonKey.FromPropertyName(key)] = value;
         }
 
@@ -82,14 +82,14 @@ internal sealed class JsonSectionWriter(string name) : ISectionWriter
         return result;
     }
 
-    private static (string Key, object? Value) TransformByConvention(string name, object? raw, ColumnSuffix suffix)
-        => suffix switch
+    private static (string Key, object? Value) TransformByConvention(string name, object? raw, ColumnKind kind)
+        => kind switch
         {
             // Flag columns are pre-formatted by the engine as "X" / "" strings — turn them back into booleans.
-            ColumnSuffix.Flag => (name[..^4], raw is string s ? s.Length > 0 : raw is bool b && b),
+            ColumnKind.Flag => (name[..^4], raw is string s ? s.Length > 0 : raw is bool b && b),
             // Wrap columns are just text with multi-line content — keep value, strip the suffix from the key.
-            ColumnSuffix.Wrap => (name[..^4], raw),
-            // GB / MB / Pct / Date / None: keep the raw value as the engine produced it.
+            ColumnKind.Wrap => (name[..^4], raw),
+            // GB / MB / Percentage / DateOnly / Text: keep the raw value as the engine produced it.
             _ => (name, raw),
         };
 }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonSectionWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonSectionWriter.cs
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
+
+/// <summary>
+/// Section writer that captures the engine's calls (AddTable / AddKeyValue / AddKeyValueRow)
+/// into structured data ready for serialisation. The parent <see cref="JsonReportWriter"/>
+/// post-processes these blocks at SaveAsync time to produce the multi-file JSON layout.
+/// </summary>
+internal sealed class JsonSectionWriter(string name) : ISectionWriter
+{
+    public string Name { get; } = name;
+
+    /// <summary>Ordered list of "blocks" captured for this section (KeyValue / KeyValueRow / Table).</summary>
+    public List<JsonBlock> Blocks { get; } = [];
+
+    /// <summary>HTML/XLSX have a Back link concept; ignored in JSON.</summary>
+    public void AddBackLink(string label, string linkKey) { }
+
+    public void AddKeyValue(string title, IDictionary<string, object?> items)
+        => Blocks.Add(new JsonBlock.KeyValue(title, NormaliseKeyValue(items)));
+
+    public void AddKeyValueRow(params (string Title, IDictionary<string, object?> Items)[] blocks)
+    {
+        foreach (var (title, items) in blocks)
+        {
+            Blocks.Add(new JsonBlock.KeyValue(title, NormaliseKeyValue(items)));
+        }
+    }
+
+    public ITableHandle AddTable<T>(string? title, IEnumerable<T> data, TableOptions<T>? options = null)
+    {
+        var rows = data is IList<T> list ? list : [.. data];
+        var serialisable = rows.Select(r => NormaliseRow(r)).Cast<object?>().ToList();
+        Blocks.Add(new JsonBlock.Table(title, serialisable));
+        return new JsonTableHandle(title ?? "", serialisable);
+    }
+
+    public void AppendData<T>(ITableHandle table, IEnumerable<T> data)
+    {
+        var handle = (JsonTableHandle)table;
+        foreach (var row in data) { handle.Rows.Add(NormaliseRow(row)); }
+    }
+
+    public void Dispose() { }
+
+    /// <summary>
+    /// Decode the conventional column-name suffixes (Flag/Wrap/Pct/GB/MB/Date) into JSON-friendly
+    /// values: flag-strings become booleans, "Wrap" suffix is stripped, etc. Mirrors what the
+    /// XLSX/HTML writers do for header rendering, but applied to property names of the row.
+    /// </summary>
+    private static IDictionary<string, object?> NormaliseRow<T>(T row)
+    {
+        if (row is null) { return new Dictionary<string, object?>(); }
+
+        var props = row.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        var result = new Dictionary<string, object?>(props.Length);
+
+        foreach (var p in props)
+        {
+            var (suffix, _) = ColumnNameSuffix.Parse(p.Name);
+            var raw = p.GetValue(row);
+            var (key, value) = TransformByConvention(p.Name, raw, suffix);
+            result[ToCamelCase(key)] = value;
+        }
+
+        return result;
+    }
+
+    private static IDictionary<string, object?> NormaliseKeyValue(IDictionary<string, object?> items)
+    {
+        var result = new Dictionary<string, object?>(items.Count);
+        foreach (var (k, v) in items)
+        {
+            // Key-value blocks use display-style keys ("VM ID", "On Boot"). Keep as-is.
+            result[k] = v;
+        }
+        return result;
+    }
+
+    private static (string Key, object? Value) TransformByConvention(string name, object? raw, ColumnSuffix suffix)
+        => suffix switch
+        {
+            // Flag columns are pre-formatted by the engine as "X" / "" strings — turn them back into booleans.
+            ColumnSuffix.Flag => (name[..^4], raw is string s ? s.Length > 0 : raw is bool b && b),
+            // Wrap columns are just text with multi-line content — keep value, strip the suffix from the key.
+            ColumnSuffix.Wrap => (name[..^4], raw),
+            // GB / MB / Pct / Date / None: keep the raw value as the engine produced it.
+            _ => (name, raw),
+        };
+
+    private static string ToCamelCase(string name)
+    {
+        if (string.IsNullOrEmpty(name) || char.IsLower(name[0])) { return name; }
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}
+
+/// <summary>Discriminated record for the kinds of block a section can carry.</summary>
+internal abstract record JsonBlock
+{
+    public sealed record KeyValue(string Title, IDictionary<string, object?> Items) : JsonBlock;
+    public sealed record Table(string? Title, IList<object?> Rows) : JsonBlock;
+}

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonSectionWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonSectionWriter.cs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+using static Corsinvest.ProxmoxVE.Report.Writers.Json.JsonBlock;
+
 namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
 
 /// <summary>
@@ -13,21 +15,16 @@ namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
 internal sealed class JsonSectionWriter(string name) : ISectionWriter
 {
     public string Name { get; } = name;
-
-    /// <summary>Ordered list of "blocks" captured for this section (KeyValue / KeyValueRow / Table).</summary>
     public List<JsonBlock> Blocks { get; } = [];
 
-    /// <summary>HTML/XLSX have a Back link concept; ignored in JSON.</summary>
     public void AddBackLink(string label, string linkKey) { }
-
-    public void AddKeyValue(string title, IDictionary<string, object?> items)
-        => Blocks.Add(new JsonBlock.KeyValue(title, NormaliseKeyValue(items)));
+    public void AddKeyValue(string title, IDictionary<string, object?> items) => Blocks.Add(new KeyValue(title, NormaliseKeyValue(items)));
 
     public void AddKeyValueRow(params (string Title, IDictionary<string, object?> Items)[] blocks)
     {
         foreach (var (title, items) in blocks)
         {
-            Blocks.Add(new JsonBlock.KeyValue(title, NormaliseKeyValue(items)));
+            Blocks.Add(new KeyValue(title, NormaliseKeyValue(items)));
         }
     }
 
@@ -35,7 +32,7 @@ internal sealed class JsonSectionWriter(string name) : ISectionWriter
     {
         var rows = data is IList<T> list ? list : [.. data];
         var serialisable = rows.Select(r => NormaliseRow(r)).Cast<object?>().ToList();
-        Blocks.Add(new JsonBlock.Table(title, serialisable));
+        Blocks.Add(new Table(title, serialisable));
         return new JsonTableHandle(title ?? "", serialisable);
     }
 
@@ -64,19 +61,23 @@ internal sealed class JsonSectionWriter(string name) : ISectionWriter
             var (suffix, _) = ColumnNameSuffix.Parse(p.Name);
             var raw = p.GetValue(row);
             var (key, value) = TransformByConvention(p.Name, raw, suffix);
-            result[ToCamelCase(key)] = value;
+            result[JsonKey.FromPropertyName(key)] = value;
         }
 
         return result;
     }
 
+    /// <summary>
+    /// Convert key-value blocks (as authored for Excel/HTML rendering, with
+    /// human-readable keys like "VM ID", "On Boot", "Memory Host %") into
+    /// JSON-friendly identifier keys ("vmID", "onBoot", "memoryHost").
+    /// </summary>
     private static IDictionary<string, object?> NormaliseKeyValue(IDictionary<string, object?> items)
     {
         var result = new Dictionary<string, object?>(items.Count);
         foreach (var (k, v) in items)
         {
-            // Key-value blocks use display-style keys ("VM ID", "On Boot"). Keep as-is.
-            result[k] = v;
+            result[JsonKey.FromDisplay(k)] = v;
         }
         return result;
     }
@@ -91,12 +92,6 @@ internal sealed class JsonSectionWriter(string name) : ISectionWriter
             // GB / MB / Pct / Date / None: keep the raw value as the engine produced it.
             _ => (name, raw),
         };
-
-    private static string ToCamelCase(string name)
-    {
-        if (string.IsNullOrEmpty(name) || char.IsLower(name[0])) { return name; }
-        return char.ToLowerInvariant(name[0]) + name[1..];
-    }
 }
 
 /// <summary>Discriminated record for the kinds of block a section can carry.</summary>

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonTableHandle.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonTableHandle.cs
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report.Writers.Json;
+
+/// <summary>
+/// Handle returned by JsonSectionWriter.AddTable so callers can later append rows
+/// to an already-created table via AppendData.
+/// </summary>
+internal sealed record JsonTableHandle(string Title, System.Collections.IList Rows) : ITableHandle;


### PR DESCRIPTION
## Summary

Adds a third output format alongside Xlsx and Html: `--format Json` produces a multi-file zipped JSON dataset (one file per section + per-resource detail under `vms/`, `nodes/`, `containers/`), ready to be consumed with `jq`, Power BI, Python or any JSON-aware tool.

- **Writers/Json/** — new `JsonReportWriter` mirroring the Xlsx/Html implementations (auto-registered `section:*` links, `ZipHelpers.WriteNetworkDiagramAsync`, `JsonStringEnumConverter` so `VmDisk.Kind` serialises as `\"Disk\"`/`\"CDRom\"`/`\"CloudInit\"`).
- **Stable, predictable schema** — overview files (`vms.json`, `disks.json`, …) are flat arrays; detail files (`vms/<id>.json`, `nodes/<name>.json`, `cluster.json`, …) are objects keyed by block title, with the first KeyValue always under the fixed `\"info\"` key (no more title-derived slugs like `\"106DanielPDCM\"`).
- **`metadata.json`** carries schema version, timestamp, app info, the same filter set as the Xlsx Summary sheet / Html cover, and a per-section generation log.
- **Naming conventions** — camelCase keys, acronyms preserved (`vmID`, `osType`, `agentOSInfo`), nulls dropped, flag columns emitted as real JSON booleans, unit in the key suffix (`memorySizeGB`, `cpuUsagePct`).
- **Docs** — full reference at [`docs/format-json.md`](docs/format-json.md) with file layout, schema, jq recipes and snapshot-diff workflow. README updated with a JSON section symmetric to Xlsx/Html.

## Test plan

- [x] `--format Json` against the test cluster (cc01/cc02) — all sections written, network-diagram.svg bundled
- [x] Detail files use stable `info` key (verified on `vms/*.json`, `containers/*.json`, `nodes/*.json`, `cluster.json`)
- [x] `VmDisk.Kind` serialises as string in `disks.json`
- [ ] `jq` smoke recipes from [`docs/format-json.md`](docs/format-json.md) on a fresh extract
- [ ] Compare snapshot diff workflow: two reports against the same cluster → `diff -r` only shows real changes