### PR TITLE
fix(rrd-nodes): treat IoWait as percentage

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdNode.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.RrdNode.cs
@@ -34,7 +34,7 @@ public partial class ReportEngine
                         item.Node,
                         a.TimeDate,
                         CpuUsagePct = a.CpuUsagePercentage,
-                        a.IoWait,
+                        IoWaitPct = a.IoWait,
                         a.Loadavg,
                         MemorySizeGB = ToGB(a.MemorySize),
                         MemoryUsageGB = ToGB(a.MemoryUsage),


### PR DESCRIPTION
Closes #43.

## Summary

In the `RRD Nodes` table the `Io Wait` column always rendered as `0` in Excel and HTML because the value coming from Proxmox is a fraction 0–1 (e.g. `0.0002` = 0.02%) and the engine was forwarding it without the `Pct` suffix, so the formatter rounded it to `0`.

Renaming `a.IoWait` → `IoWaitPct = a.IoWait` in `ReportEngine.RrdNode.cs` is enough — the `Pct` suffix is the existing convention that triggers the `× 100` + `0.00 %` formatting already used for `cpuUsagePct`, `memoryUsagePct`, `psi*Pct`, etc.

## Test plan

- [x] `dotnet build` clean
- [ ] Generate XLSX/HTML/JSON against the test cluster and confirm Io Wait now shows real sub-percent values (e.g. `0.02 %`, `0.15 %`) instead of `0`
- [ ] JSON key changes from `ioWait` (raw) to `ioWaitPct` — consistent with `cpuUsagePct`, etc.