### PR TITLE
chore: drop unused engine helpers, unify on LinkKey

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Storage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Storage.cs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Report.Writers;
 
 namespace Corsinvest.ProxmoxVE.Report;

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Storage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.Storage.cs
@@ -16,7 +16,7 @@ public partial class ReportEngine
 
         foreach (var a in filtered)
         {
-            _writer.Links[SheetLinkKey(ClusterResourceType.Storage, StorageNode(a), a.Storage)] = "Storages";
+            _writer.Links[LinkKey.Storage(StorageNode(a), a.Storage)] = "Storages";
         }
 
         using var sw = _writer.AddSection("Storages");

--- a/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/ReportEngine.cs
@@ -62,14 +62,6 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
             _ => _resources.Where(a => a.ResourceType == type),
         };
 
-    private string? GetSheetName(ClusterResourceType type, params string[] values)
-        => _writer.Links.TryGetValue(SheetLinkKey(type, values), out var name)
-            ? name
-            : null;
-
-    internal static string SheetLinkKey(ClusterResourceType type, params string[] values)
-        => $"{type.ToString().ToLowerInvariant()}:{values.JoinAsString(":")}";
-
     private async Task LoadResourcesAsync()
     {
         _resources = [.. await client.GetResourcesAsync(ClusterResourceType.All)];
@@ -123,11 +115,11 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
             switch (item.ResourceType)
             {
                 case ClusterResourceType.Node:
-                    _writer.Links[SheetLinkKey(ClusterResourceType.Node, item.Node)] = $"Node {item.Node}";
+                    _writer.Links[LinkKey.Node(item.Node)] = $"Node {item.Node}";
                     break;
 
                 case ClusterResourceType.Vm:
-                    _writer.Links[SheetLinkKey(ClusterResourceType.Vm, item.VmId.ToString())] = $"{VmTypeLabel(item.VmType)} {item.VmId}";
+                    _writer.Links[LinkKey.Vm(item.VmId)] = $"{VmTypeLabel(item.VmType)} {item.VmId}";
                     break;
             }
         }
@@ -228,11 +220,6 @@ public partial class ReportEngine(PveClient client, Settings settings, ReportInf
 
     internal static string VmTypeLabel(VmType type)
         => type == VmType.Qemu
-            ? "VM"
-            : "CT";
-
-    internal static string VmTypeLabel(string? type)
-        => string.Equals(type, "qemu", StringComparison.OrdinalIgnoreCase)
             ? "VM"
             : "CT";
 

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/LinkKey.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/LinkKey.cs
@@ -15,6 +15,7 @@ internal static class LinkKey
     // Per-entity keys (parameterised).
     public static string Node(string node) => $"node:{node}";
     public static string Vm(long vmId) => $"vm:{vmId}";
+    public static string Storage(string node, string storage) => $"storage:{node}:{storage}";
     public static string NodeNetwork(string node, string iface) => $"node:{node}:network:{iface}";
     public static string List(string what) => $"list:{what}";
 


### PR DESCRIPTION
## Summary

Tidies up the `ReportEngine` by removing dead helpers and unifying cross-section link-key construction on a single source of truth.

The engine carried two parallel paths to produce the same strings (`\"node:cc01\"`, `\"vm:102\"`, `\"storage:cc01:local\"`): the old \`SheetLinkKey\`/\`GetSheetName\` pair in \`ReportEngine.cs\` and the newer \`LinkKey.*\` helpers in \`Writers/LinkKey.cs\` (added with the 2.2.0 Issues refactor). The duplication was easy to miss when adding a new link key, and the engine has no business knowing how the writers wire up cross-references.

- Replace the three \`SheetLinkKey\` call sites with \`LinkKey.Node\` / \`LinkKey.Vm\` / \`LinkKey.Storage\` (new helper for the only entity that didn't have one yet).
- Drop \`SheetLinkKey\` and its single private caller \`GetSheetName\`.
- Drop the unused \`VmTypeLabel(string?)\` overload — the typed \`VmType\` enum is the canonical input everywhere.

3 files, +4 / −16. Pure refactor, no behaviour change.

## Test plan

- [x] \`dotnet build\` clean (all 3 target frameworks)
- [x] Roslyn / Roslynator analyzers report no new warnings (IDE0051, RCS1213 already enabled in \`.editorconfig\`)
- [ ] Generate a report against the test cluster and confirm cross-section hyperlinks still resolve (Storages → per-storage row, VM list → per-VM detail, Nodes list → per-node detail).