### PR TITLE
chore: add unit tests + fix slug for hostnames with dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ---
 
+## [Unreleased]
+
+### Fixes
+
+- **Hostnames with dashes no longer collapse in HTML/JSON file paths.** A node named `pve-host01` produced `pvehost01.html` / `pvehost01.json` (dash dropped) because the slug routine treated only letters and digits as safe. It now keeps existing dashes, so the filenames match what an operator types.
+
+### Internal
+
+- **Unit tests.** A new `tests/Corsinvest.ProxmoxVE.Report.Tests` xUnit project covers the writer helpers (`ColumnConvention`, `HtmlEncoder`, `LinkKey`, `UnitFormat`) — 41 tests across net8/net9/net10. The existing `build.yml` workflow already runs `dotnet test` so they run on every PR.
+
+---
+
 ## [2.5.0] — 2026-05-27
 
 ### What's new

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,5 +6,9 @@
     <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.2.0" />
     <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.2.0" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Report/Corsinvest.ProxmoxVE.Report.csproj
+++ b/src/Corsinvest.ProxmoxVE.Report/Corsinvest.ProxmoxVE.Report.csproj
@@ -25,6 +25,9 @@
         <None Include="..\..\README.md" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="Corsinvest.ProxmoxVE.Report.Tests" />
+    </ItemGroup>
+    <ItemGroup>
         <PackageReference Include="Corsinvest.ProxmoxVE.Api.Extension" />
         <PackageReference Include="ClosedXML" />
     </ItemGroup>

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlEncoder.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlEncoder.cs
@@ -79,7 +79,7 @@ internal static class HtmlEncoder
         var slug = new StringBuilder(name.Length);
         foreach (var item in name.ToLowerInvariant())
         {
-            if (char.IsLetterOrDigit(item)) { slug.Append(item); }
+            if (char.IsLetterOrDigit(item) || item == '-') { slug.Append(item); }
             else if (item == ' ' || item == '_' || item == '/' || item == '\\') { slug.Append('-'); }
             else if (item == '.' || item == ':') { slug.Append('-'); }
         }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
@@ -99,7 +99,7 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
         var sb = new StringBuilder(name.Length);
         foreach (var c in name.ToLowerInvariant())
         {
-            if (char.IsLetterOrDigit(c)) { sb.Append(c); }
+            if (char.IsLetterOrDigit(c) || c == '-') { sb.Append(c); }
             else if (c == ' ' || c == '_' || c == '/' || c == '\\') { sb.Append('-'); }
             else if (c == '.' || c == ':') { sb.Append('-'); }
         }

--- a/tests/Corsinvest.ProxmoxVE.Report.Tests/Corsinvest.ProxmoxVE.Report.Tests.csproj
+++ b/tests/Corsinvest.ProxmoxVE.Report.Tests/Corsinvest.ProxmoxVE.Report.Tests.csproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="coverlet.collector" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Corsinvest.ProxmoxVE.Report\Corsinvest.ProxmoxVE.Report.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+</Project>

--- a/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/ColumnConventionTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/ColumnConventionTests.cs
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.ProxmoxVE.Report.Writers;
+
+namespace Corsinvest.ProxmoxVE.Report.Tests.Writers;
+
+internal class ColumnConventionTests
+{
+    [Theory]
+    [InlineData("CpuUsagePct", ColumnKind.Percentage, "Cpu Usage %")]
+    [InlineData("MemoryUsageGB", ColumnKind.GB, "Memory Usage GB")]
+    [InlineData("DiskUsageMB", ColumnKind.MB, "Disk Usage MB")]
+    [InlineData("DescriptionWrap", ColumnKind.Wrap, "Description")]
+    [InlineData("EnableFlag", ColumnKind.Flag, "Enable")]
+    [InlineData("StartDate", ColumnKind.DateOnly, "Start Date")]
+    public void Parse_RecognisesSuffixConventions(string input, ColumnKind expectedKind, string expectedLabel)
+    {
+        var (kind, label) = ColumnConvention.Parse(input);
+
+        Assert.Equal(expectedKind, kind);
+        Assert.Equal(expectedLabel, label);
+    }
+
+    [Fact]
+    public void Parse_HealthScore_StripsScoreFromLabel()
+    {
+        var (kind, label) = ColumnConvention.Parse("CpuHealthScore");
+
+        Assert.Equal(ColumnKind.HealthScore, kind);
+        Assert.Equal("Cpu Health", label);
+    }
+
+    [Theory]
+    [InlineData("PlainText")]
+    [InlineData("NodeName")]
+    public void Parse_PascalCaseWithoutSuffix_IsTextWithWords(string input)
+    {
+        var (kind, label) = ColumnConvention.Parse(input);
+
+        Assert.Equal(ColumnKind.Text, kind);
+        Assert.Equal(ColumnConvention.PascalCaseToWords(input), label);
+    }
+
+    [Theory]
+    [InlineData("VM ID")]
+    [InlineData("CPU Usage %")]
+    [InlineData("vCPUs")]
+    public void Parse_DisplayLabel_IsKeptVerbatim(string input)
+    {
+        var (_, label) = ColumnConvention.Parse(input);
+
+        Assert.Equal(input, label);
+    }
+
+    [Fact]
+    public void Parse_HumanGBLabel_StaysGBKind()
+    {
+        var (kind, label) = ColumnConvention.Parse("Memory GB");
+
+        Assert.Equal(ColumnKind.GB, kind);
+        Assert.Equal("Memory GB", label);
+    }
+
+    [Fact]
+    public void PascalCaseToWords_SplitsOnUpperCase()
+    {
+        Assert.Equal("Cpu Usage Percentage", ColumnConvention.PascalCaseToWords("CpuUsagePercentage"));
+        Assert.Equal("VM Id", ColumnConvention.PascalCaseToWords("VMId"));
+    }
+
+    [Fact]
+    public void Parse_PropertyInfo_FallbackToCLRType_Numeric()
+    {
+        var prop = typeof(SampleRow).GetProperty(nameof(SampleRow.Count))!;
+
+        var (kind, label) = ColumnConvention.Parse(prop);
+
+        Assert.Equal(ColumnKind.Number, kind);
+        Assert.Equal("Count", label);
+    }
+
+    [Fact]
+    public void Parse_PropertyInfo_FallbackToCLRType_DateTime()
+    {
+        var prop = typeof(SampleRow).GetProperty(nameof(SampleRow.Created))!;
+
+        var (kind, label) = ColumnConvention.Parse(prop);
+
+        Assert.Equal(ColumnKind.DateTime, kind);
+        Assert.Equal("Created", label);
+    }
+
+    [Fact]
+    public void Parse_PropertyInfo_SuffixWinsOverCLRType()
+    {
+        // long is numeric, but the "GB" suffix must take precedence so the writer formats it as GB.
+        var prop = typeof(SampleRow).GetProperty(nameof(SampleRow.MemoryGB))!;
+
+        var (kind, _) = ColumnConvention.Parse(prop);
+
+        Assert.Equal(ColumnKind.GB, kind);
+    }
+
+    private sealed class SampleRow
+    {
+        public int Count { get; set; }
+        public DateTime Created { get; set; }
+        public long MemoryGB { get; set; }
+    }
+}

--- a/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/Html/HtmlEncoderTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/Html/HtmlEncoderTests.cs
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.ProxmoxVE.Report.Writers.Html;
+
+namespace Corsinvest.ProxmoxVE.Report.Tests.Writers.Html;
+
+public class HtmlEncoderTests
+{
+    [Theory]
+    [InlineData("Cluster", "cluster.html")]
+    [InlineData("Storages", "storages.html")]
+    [InlineData("Cluster Access", "cluster-access.html")]
+    [InlineData("RRD Nodes", "rrd-nodes.html")]
+    public void PageFileName_TopLevelSections_GoToRoot(string sectionName, string expected)
+    {
+        Assert.Equal(expected, HtmlEncoder.PageFileName(sectionName));
+    }
+
+    [Theory]
+    [InlineData("Node cc01", "nodes/cc01.html")]
+    [InlineData("Node pve-host.example.com", "nodes/pve-host-example-com.html")]
+    [InlineData("VM 100", "vms/100.html")]
+    [InlineData("CT 200", "containers/200.html")]
+    public void PageFileName_DetailSections_GoToSubfolders(string sectionName, string expected)
+    {
+        Assert.Equal(expected, HtmlEncoder.PageFileName(sectionName));
+    }
+
+    [Theory]
+    [InlineData("Cluster", 0)]
+    [InlineData("Storages", 0)]
+    [InlineData("Node cc01", 1)]
+    [InlineData("VM 100", 1)]
+    [InlineData("CT 200", 1)]
+    public void PageDepth_CountsSubdirectorySegments(string sectionName, int expected)
+    {
+        Assert.Equal(expected, HtmlEncoder.PageDepth(sectionName));
+    }
+
+    [Theory]
+    [InlineData("plain text", "plain text")]
+    [InlineData("a & b", "a &amp; b")]
+    [InlineData("<script>", "&lt;script&gt;")]
+    [InlineData("name=\"value\"", "name=&quot;value&quot;")]
+    [InlineData("it's", "it&#39;s")]
+    public void Text_EscapesHtmlEntities(string input, string expected)
+    {
+        Assert.Equal(expected, HtmlEncoder.Text(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Text_NullOrEmpty_ReturnsEmpty(string? input)
+    {
+        Assert.Equal("", HtmlEncoder.Text(input));
+    }
+
+    [Fact]
+    public void PageHref_EncodesPathForAttribute()
+    {
+        // Path itself doesn't need extra encoding here, but the helper should round-trip through Attr.
+        Assert.Equal("nodes/cc01.html", HtmlEncoder.PageHref("Node cc01"));
+    }
+}

--- a/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/LinkKeyTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/LinkKeyTests.cs
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.ProxmoxVE.Report.Writers;
+
+namespace Corsinvest.ProxmoxVE.Report.Tests.Writers;
+
+public class LinkKeyTests
+{
+    [Fact]
+    public void Node_BuildsNodeKey()
+    {
+        Assert.Equal("node:cc01", LinkKey.Node("cc01"));
+    }
+
+    [Fact]
+    public void Vm_BuildsVmKeyFromId()
+    {
+        Assert.Equal("vm:100", LinkKey.Vm(100));
+    }
+
+    [Fact]
+    public void Storage_BuildsCompositeKey()
+    {
+        Assert.Equal("storage:cc01:local-zfs", LinkKey.Storage("cc01", "local-zfs"));
+    }
+
+    [Fact]
+    public void NodeNetwork_BuildsCompositeKey()
+    {
+        Assert.Equal("node:cc01:network:vmbr0", LinkKey.NodeNetwork("cc01", "vmbr0"));
+    }
+
+    [Theory]
+    [InlineData("Cluster", "section:cluster")]
+    [InlineData("Cluster Access", "section:cluster-access")]
+    [InlineData("Storages", "section:storages")]
+    [InlineData("RRD Nodes", "section:rrd-nodes")]
+    [InlineData("Firewall", "section:firewall")]
+    public void ForSection_KnownSection_ReturnsCanonicalKey(string sectionName, string expected)
+    {
+        Assert.Equal(expected, LinkKey.ForSection(sectionName));
+    }
+
+    [Theory]
+    [InlineData("Node cc01")]
+    [InlineData("VM 100")]
+    [InlineData("CT 200")]
+    [InlineData("Unknown Section")]
+    public void ForSection_DetailOrUnknown_ReturnsNull(string sectionName)
+    {
+        Assert.Null(LinkKey.ForSection(sectionName));
+    }
+
+    [Fact]
+    public void ForSection_KnownSections_AreUnique()
+    {
+        var allSections = new[]
+        {
+            "Cluster", "Cluster Access", "Cluster SDN", "Cluster HA", "Cluster Pools",
+            "Cluster Log", "Cluster Tasks", "Storages", "Storage Content", "Backups",
+            "Disks", "Partitions", "Snapshots", "Network", "Firewall", "Replication",
+            "RRD Nodes", "RRD Storage", "RRD Guests", "Syslog", "Issues",
+        };
+
+        var keys = allSections.Select(LinkKey.ForSection).ToList();
+
+        Assert.All(keys, k => Assert.NotNull(k));
+        Assert.Equal(allSections.Length, keys.Distinct().Count());
+    }
+}

--- a/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/UnitFormatTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/UnitFormatTests.cs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.ProxmoxVE.Report.Writers;
+
+namespace Corsinvest.ProxmoxVE.Report.Tests.Writers;
+
+public class UnitFormatTests
+{
+    [Fact]
+    public void BytesToGB_ConvertsExactlyOneGiB()
+    {
+        Assert.Equal(1.0, UnitFormat.BytesToGB(1024d * 1024 * 1024), 10);
+    }
+
+    [Fact]
+    public void BytesToMB_ConvertsExactlyOneMiB()
+    {
+        Assert.Equal(1.0, UnitFormat.BytesToMB(1024d * 1024), 10);
+    }
+
+    [Fact]
+    public void BytesToGB_Zero_ReturnsZero()
+    {
+        Assert.Equal(0.0, UnitFormat.BytesToGB(0));
+    }
+
+    [Fact]
+    public void BytesToMB_Zero_ReturnsZero()
+    {
+        Assert.Equal(0.0, UnitFormat.BytesToMB(0));
+    }
+
+    [Fact]
+    public void BytesToGB_HalfGiB_IsHalf()
+    {
+        Assert.Equal(0.5, UnitFormat.BytesToGB(512d * 1024 * 1024), 10);
+    }
+
+    [Fact]
+    public void BytesToMB_TenMiB_IsTen()
+    {
+        Assert.Equal(10.0, UnitFormat.BytesToMB(10d * 1024 * 1024), 10);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first **unit test project** for cv4pve-report. Along the way the tests caught a real bug in the URL slug routine that affected hostnames containing literal dashes (e.g. \`pve-host01\` → file named \`pvehost01.html\`).

## Changes

- **New test project** \`tests/Corsinvest.ProxmoxVE.Report.Tests\` (xUnit, multi-target net8/net9/net10). 41 tests covering:
  - \`ColumnConvention\` — suffix detection (Pct/GB/MB/Wrap/Flag/Date/HealthScore), PascalCase splitting, CLR-type fallback
  - \`HtmlEncoder\` — \`PageFileName\` routing for top-level/detail sections, \`PageDepth\`, HTML entity escaping
  - \`LinkKey\` — key builders (\`Node\`, \`Vm\`, \`Storage\`, \`NodeNetwork\`), section-name → canonical key mapping
  - \`UnitFormat\` — bytes → GB/MB
- **\`InternalsVisibleTo\`** in the main csproj so tests can exercise the (intentionally narrow) internal helper surface.
- **Slug fix** in \`HtmlEncoder.Slug\` and \`JsonReportWriter.Slug\`: literal \`-\` is now preserved in slugs, instead of being silently dropped. Both implementations were duplicated and shared the same bug.

## CI

The existing \`build.yml\` workflow already runs \`dotnet test\`, so the new tests run on every PR with no workflow changes.

## Test plan

- [x] \`dotnet test\` green on net8 / net9 / net10 (41/41 passed)
- [ ] CI green on GitHub Actions