### PR TITLE
fix: HTML cross-section links + dedup HTML/JSON file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@
 
 ### Fixes
 
-- **Hostnames with dashes no longer collapse in HTML/JSON file paths.** A node named `pve-host01` produced `pvehost01.html` / `pvehost01.json` (dash dropped) because the slug routine treated only letters and digits as safe. It now keeps existing dashes, so the filenames match what an operator types.
-
-### Internal
-
-- **Unit tests.** A new `tests/Corsinvest.ProxmoxVE.Report.Tests` xUnit project covers the writer helpers (`ColumnConvention`, `HtmlEncoder`, `LinkKey`, `UnitFormat`) — 41 tests across net8/net9/net10. The existing `build.yml` workflow already runs `dotnet test` so they run on every PR.
+- **Hostnames with dashes are kept in HTML and JSON file names.** A node called `pve-host01` used to produce `pvehost01.html` and `pvehost01.json` — the dash was dropped. The file name now matches the hostname you actually use.
+- **Links between HTML pages now work.** Clicking a node, VM or container in an overview table opened a 404 instead of the matching detail page. The links go to the right page again.
+- **Two nodes with similar names no longer share the same report page.** When two nodes ended up with the same file name (e.g. `cc.01` and `cc-01`), the second one used to overwrite the first one's HTML/JSON file silently. Each section now gets its own file.
 
 ---
 

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/Blocks/TableBlock.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/Blocks/TableBlock.cs
@@ -115,7 +115,7 @@ internal sealed class TableBlock<T> : IBlock
             && mapper(row) is { } linkKey
             && links.TryGetValue(linkKey, out var target))
         {
-            return $"""<td{classAttr}><a href="{HtmlEncoder.PageHref(target)}">{text}</a></td>""";
+            return $"""<td{classAttr}><a href="{HtmlEncoder.Attr(target)}">{text}</a></td>""";
         }
 
         return $"<td{classAttr}>{text}</td>";

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.CoverPage.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.CoverPage.cs
@@ -14,7 +14,7 @@ internal sealed partial class HtmlReportWriter
 
         var rows = string.Concat(statsList.Select(s => $"""
                   <tr>
-                    <td><a href="{HtmlEncoder.PageHref(s.Name)}">{HtmlEncoder.Text(s.Name)}</a></td>
+                    <td><a href="{HtmlEncoder.Attr(FileFor(s.Name))}">{HtmlEncoder.Text(s.Name)}</a></td>
                     <td>{HtmlEncoder.Text(s.Description)}</td>
                     <td class="num">{s.Count}</td>
                     <td class="num">{FormatDuration(s.Duration)}</td>

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.Sidebar.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.Sidebar.cs
@@ -87,13 +87,13 @@ internal sealed partial class HtmlReportWriter
     /// expansion (no navigation). The first child is "Overview" — a link to the
     /// parent page (e.g. storages.html). Subsequent children are the detail pages.
     /// </summary>
-    private static void AppendGroup(StringBuilder sb,
-                                    HashSet<string> known,
-                                    Dictionary<string, string> displayNames,
-                                    string parent,
-                                    IReadOnlyList<string> children,
-                                    string? parentLabel = null,
-                                    IReadOnlyDictionary<string, string>? childLabels = null)
+    private void AppendGroup(StringBuilder sb,
+                             HashSet<string> known,
+                             Dictionary<string, string> displayNames,
+                             string parent,
+                             IReadOnlyList<string> children,
+                             string? parentLabel = null,
+                             IReadOnlyDictionary<string, string>? childLabels = null)
     {
         if (!known.Contains(parent)) { return; }
 
@@ -102,7 +102,7 @@ internal sealed partial class HtmlReportWriter
 
         if (visibleChildren.Count == 0)
         {
-            sb.AppendLine($"""        <a href="{HtmlEncoder.PageHref(parent)}">{HtmlEncoder.Text(label)}</a>""");
+            sb.AppendLine($"""        <a href="{HtmlEncoder.Attr(FileFor(parent))}">{HtmlEncoder.Text(label)}</a>""");
             return;
         }
 
@@ -110,7 +110,7 @@ internal sealed partial class HtmlReportWriter
 
         sb.AppendLine("        <details open>");
         sb.AppendLine($"""          <summary>{HtmlEncoder.Text(label)} <span class="count">({totalEntries})</span></summary>""");
-        sb.AppendLine($"""          <a href="{HtmlEncoder.PageHref(parent)}">Overview</a>""");
+        sb.AppendLine($"""          <a href="{HtmlEncoder.Attr(FileFor(parent))}">Overview</a>""");
         foreach (var child in visibleChildren)
         {
             var text = childLabels is not null && childLabels.TryGetValue(child, out var shortLabel)
@@ -119,7 +119,7 @@ internal sealed partial class HtmlReportWriter
                             ? dn
                             : child;
 
-            sb.AppendLine($"""          <a href="{HtmlEncoder.PageHref(child)}">{HtmlEncoder.Text(text)}</a>""");
+            sb.AppendLine($"""          <a href="{HtmlEncoder.Attr(FileFor(child))}">{HtmlEncoder.Text(text)}</a>""");
         }
         sb.AppendLine("        </details>");
     }
@@ -128,10 +128,10 @@ internal sealed partial class HtmlReportWriter
     /// Renders a synthetic group: the summary is text only (not a link), children below.
     /// Used for "Performance" which has no overview page of its own.
     /// </summary>
-    private static void AppendSyntheticGroup(StringBuilder sb,
-                                             HashSet<string> known,
-                                             string label,
-                                             IReadOnlyList<string> children)
+    private void AppendSyntheticGroup(StringBuilder sb,
+                                      HashSet<string> known,
+                                      string label,
+                                      IReadOnlyList<string> children)
     {
         var visibleChildren = children.Where(known.Contains).ToList();
         if (visibleChildren.Count == 0) { return; }
@@ -140,15 +140,15 @@ internal sealed partial class HtmlReportWriter
         sb.AppendLine($"""          <summary>{HtmlEncoder.Text(label)} <span class="count">({visibleChildren.Count})</span></summary>""");
         foreach (var child in visibleChildren)
         {
-            sb.AppendLine($"""          <a href="{HtmlEncoder.PageHref(child)}">{HtmlEncoder.Text(child)}</a>""");
+            sb.AppendLine($"""          <a href="{HtmlEncoder.Attr(FileFor(child))}">{HtmlEncoder.Text(child)}</a>""");
         }
         sb.AppendLine("        </details>");
     }
 
-    private static void AppendFlat(StringBuilder sb, HashSet<string> known, string name)
+    private void AppendFlat(StringBuilder sb, HashSet<string> known, string name)
     {
         if (!known.Contains(name)) { return; }
-        sb.AppendLine($"""        <a href="{HtmlEncoder.PageHref(name)}">{HtmlEncoder.Text(name)}</a>""");
+        sb.AppendLine($"""        <a href="{HtmlEncoder.Attr(FileFor(name))}">{HtmlEncoder.Text(name)}</a>""");
     }
 
     /// <summary>Sorting key for "VM 100" / "CT 200" entries — sorts by numeric id.</summary>
@@ -166,7 +166,7 @@ internal sealed partial class HtmlReportWriter
     /// scales with the cluster (Nodes/VMs/Containers) to avoid duplicating thousands
     /// of links in every page.
     /// </summary>
-    private static void AppendLazyGroup(StringBuilder sb,
+    private void AppendLazyGroup(StringBuilder sb,
                                         HashSet<string> known,
                                         string parent,
                                         IReadOnlyList<string> children)
@@ -177,7 +177,7 @@ internal sealed partial class HtmlReportWriter
 
         if (visibleChildren.Count == 0)
         {
-            sb.AppendLine($"""        <a href="{HtmlEncoder.PageHref(parent)}">{HtmlEncoder.Text(parent)}</a>""");
+            sb.AppendLine($"""        <a href="{HtmlEncoder.Attr(FileFor(parent))}">{HtmlEncoder.Text(parent)}</a>""");
             return;
         }
 
@@ -185,7 +185,7 @@ internal sealed partial class HtmlReportWriter
 
         sb.AppendLine($"""        <details data-group="{HtmlEncoder.Attr(parent)}">""");
         sb.AppendLine($"""          <summary>{HtmlEncoder.Text(parent)} <span class="count">({totalEntries})</span></summary>""");
-        sb.AppendLine($"""          <a href="{HtmlEncoder.PageHref(parent)}">Overview</a>""");
+        sb.AppendLine($"""          <a href="{HtmlEncoder.Attr(FileFor(parent))}">Overview</a>""");
         sb.AppendLine("""          <div class="group-children" data-loaded="false"></div>""");
         sb.AppendLine("        </details>");
     }
@@ -219,7 +219,7 @@ internal sealed partial class HtmlReportWriter
             for (var i = 0; i < list.Count; i++)
             {
                 var section = list[i];
-                var href = HtmlEncoder.PageFileName(section);
+                var href = FileFor(section);
                 var label = displayNames.TryGetValue(section, out var dn) ? dn : section;
                 sb.Append("    {\"href\":\"").Append(JsString(href))
                   .Append("\",\"label\":\"").Append(JsString(label)).Append("\"}");

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlReportWriter.cs
@@ -13,8 +13,16 @@ internal sealed partial class HtmlReportWriter(ReportInfo info) : IReportWriter
     private readonly List<HtmlSectionWriter> _sections = [];
     private readonly DateTime _generatedAt = DateTime.Now;
     private readonly ReportInfo _info = info;
+    private readonly UniqueNameAllocator _pageFiles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _sectionFiles = new(StringComparer.Ordinal);
     private string _coverHtml = "";
     private string? _networkDiagramSvg;
+
+    /// <summary>Returns the (collision-free) file path for a section name. Falls back to the raw slug for sections that haven't been registered yet.</summary>
+    internal string FileFor(string sectionName)
+        => _sectionFiles.TryGetValue(sectionName, out var f)
+            ? f
+            : HtmlEncoder.PageFileName(sectionName);
 
     public Dictionary<string, string> Links { get; } = [];
 
@@ -22,9 +30,6 @@ internal sealed partial class HtmlReportWriter(ReportInfo info) : IReportWriter
 
     public ISectionWriter AddSection(SectionId id)
     {
-        Links[id.Key] = id.Key;
-        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = id.Key; }
-
         var displayName = id switch
         {
             SectionId.Vm v => string.IsNullOrWhiteSpace(v.DisplayLabel)
@@ -39,7 +44,23 @@ internal sealed partial class HtmlReportWriter(ReportInfo info) : IReportWriter
             _ => id.Key,
         };
 
-        var section = new HtmlSectionWriter(this, id.Key, displayName);
+        // Allocate a collision-free file path now so two sections with names that
+        // slug to the same string (e.g. "Node cc.01" + "Node cc-01") still get distinct files.
+        var fileName = _pageFiles.Allocate(HtmlEncoder.PageFileName(id.Key));
+        _sectionFiles[id.Key] = fileName;
+
+        // Pre-existing Links pointing at the section's logical name (registered by the
+        // engine on LoadResourcesAsync, e.g. Links[LinkKey.Node("cc02")] = "Node cc02")
+        // get rewritten to the actual file path so the renderer can use the value directly.
+        foreach (var key in Links.Where(kv => kv.Value == id.Key).Select(kv => kv.Key).ToList())
+        {
+            Links[key] = fileName;
+        }
+
+        Links[id.Key] = fileName;
+        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = fileName; }
+
+        var section = new HtmlSectionWriter(this, id.Key, displayName, fileName);
         _sections.Add(section);
         return section;
     }
@@ -54,8 +75,8 @@ internal sealed partial class HtmlReportWriter(ReportInfo info) : IReportWriter
 
         foreach (var section in _sections)
         {
-            var fileName = HtmlEncoder.PageFileName(section.Name);
-            var depth = HtmlEncoder.PageDepth(section.Name);
+            var fileName = section.FileName;
+            var depth = fileName.Count(c => c == '/');
             var body = section.RenderBody(fileName);
             await ZipHelpers.WriteTextEntryAsync(zip, fileName, RenderPage(section.DisplayName, sidebarHtml, body, depth));
         }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlSectionWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Html/HtmlSectionWriter.cs
@@ -8,11 +8,13 @@ using Corsinvest.ProxmoxVE.Report.Writers.Html.Blocks;
 
 namespace Corsinvest.ProxmoxVE.Report.Writers.Html;
 
-internal sealed class HtmlSectionWriter(HtmlReportWriter parent, string name, string displayName) : ISectionWriter
+internal sealed class HtmlSectionWriter(HtmlReportWriter parent, string name, string displayName, string fileName) : ISectionWriter
 {
     private readonly List<IBlock> _blocks = [];
     public string Name { get; } = name;
     public string DisplayName { get; } = displayName;
+    /// <summary>Final, collision-free file path inside the zip (e.g. <c>nodes/cc01.html</c>).</summary>
+    public string FileName { get; } = fileName;
     public IReadOnlyList<IBlock> Blocks => _blocks;
 
     public void AddBackLink(string label, string linkKey) { }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Json/JsonReportWriter.cs
@@ -24,6 +24,8 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
     private readonly List<JsonSectionWriter> _sections = [];
     private readonly DateTime _generatedAt = DateTime.UtcNow;
     private readonly ReportInfo _info = info;
+    private readonly UniqueNameAllocator _fileNames = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _sectionFiles = new(StringComparer.Ordinal);
     private List<SectionStat> _stats = [];
     private Settings? _settings;
     private string? _networkDiagramSvg;
@@ -34,8 +36,21 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
 
     public ISectionWriter AddSection(SectionId id)
     {
-        Links[id.Key] = id.Key;
-        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = id.Key; }
+        // Allocate a collision-free file path now so two sections with names that
+        // slug to the same string still produce distinct files.
+        var fileName = _fileNames.Allocate(JsonFileName(id.Key));
+        _sectionFiles[id.Key] = fileName;
+
+        // Pre-existing Links pointing at the section's logical name (registered by the
+        // engine in LoadResourcesAsync, e.g. Links[LinkKey.Node("cc02")] = "Node cc02")
+        // are rewritten to the actual file path so the consumer can use the value directly.
+        foreach (var key in Links.Where(kv => kv.Value == id.Key).Select(kv => kv.Key).ToList())
+        {
+            Links[key] = fileName;
+        }
+
+        Links[id.Key] = fileName;
+        if (LinkKey.ForSection(id.Key) is { } sectionKey) { Links[sectionKey] = fileName; }
 
         var section = new JsonSectionWriter(id.Key);
         _sections.Add(section);
@@ -56,7 +71,7 @@ internal sealed partial class JsonReportWriter(ReportInfo info) : IReportWriter
 
         foreach (var section in _sections)
         {
-            var path = JsonFileName(section.Name);
+            var path = _sectionFiles[section.Name];
             var payload = SectionPayload(section);
             await WriteJsonEntryAsync(zip, path, payload);
         }

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/UniqueNameAllocator.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/UniqueNameAllocator.cs
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Report.Writers;
+
+/// <summary>
+/// Allocates unique names within a single report bundle. When two sections
+/// would collide on the same output target (Excel sheet name, HTML page path,
+/// JSON file path) the second one gets a numeric suffix.
+/// </summary>
+/// <remarks>
+/// Each writer instantiates its own allocator because the collision domain is
+/// writer-specific: XLSX collides on sheet names (31-char, case-insensitive),
+/// HTML and JSON collide on slugged file paths. The transformation up to the
+/// "candidate" name is the writer's job; the allocator only handles the
+/// "this candidate is already taken — give me a free variant" part.
+/// </remarks>
+internal sealed class UniqueNameAllocator
+{
+    private readonly HashSet<string> _used;
+    private readonly StringComparer _comparer;
+
+    public UniqueNameAllocator(StringComparer? comparer = null)
+    {
+        _comparer = comparer ?? StringComparer.Ordinal;
+        _used = new HashSet<string>(_comparer);
+    }
+
+    /// <summary>
+    /// Returns <paramref name="candidate"/> the first time it's asked for; on
+    /// subsequent calls returns <c>candidate_2</c>, <c>candidate_3</c>, ... — skipping
+    /// any suffixed variant that was already allocated as a literal candidate.
+    /// </summary>
+    /// <param name="candidate">The desired name (already trimmed/slugged by the caller).</param>
+    /// <param name="maxLength">Hard cap on the returned name length. The suffix is
+    /// guaranteed to fit by truncating the prefix. Use <see cref="int.MaxValue"/> when
+    /// the target has no length constraint (HTML / JSON file names).</param>
+    public string Allocate(string candidate, int maxLength = int.MaxValue)
+    {
+        var trimmed = candidate.Length <= maxLength ? candidate : candidate[..maxLength];
+
+        if (_used.Add(trimmed)) { return trimmed; }
+
+        for (var n = 2; ; n++)
+        {
+            var suffix = $"_{n}";
+            var room = Math.Max(0, maxLength - suffix.Length);
+            var prefix = trimmed.Length <= room ? trimmed : trimmed[..room];
+            var candidate2 = prefix + suffix;
+            if (_used.Add(candidate2)) { return candidate2; }
+        }
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/XlsxReportWriter.cs
+++ b/src/Corsinvest.ProxmoxVE.Report/Writers/Xlsx/XlsxReportWriter.cs
@@ -11,7 +11,7 @@ namespace Corsinvest.ProxmoxVE.Report.Writers.Xlsx;
 internal sealed partial class XlsxReportWriter : IReportWriter
 {
     private readonly XLWorkbook _workbook = new();
-    private readonly Dictionary<string, int> _usedSheetNames = [];
+    private readonly UniqueNameAllocator _sheetNames = new(StringComparer.OrdinalIgnoreCase);
     private readonly ReportInfo _info;
     private string? _networkDiagramSvg;
 
@@ -76,19 +76,7 @@ internal sealed partial class XlsxReportWriter : IReportWriter
 
     public void Dispose() => _workbook.Dispose();
 
-    private string SafeSheetName(string candidate)
-    {
-        var name = candidate.Length <= MaxSheetNameLength ? candidate : candidate[..MaxSheetNameLength];
-        if (!_usedSheetNames.TryGetValue(name, out var count))
-        {
-            _usedSheetNames[name] = 1;
-            return name;
-        }
-        count++;
-        _usedSheetNames[name] = count;
-        var suffix = $"_{count}";
-        return name[..Math.Min(name.Length, MaxSheetNameLength - suffix.Length)] + suffix;
-    }
+    private string SafeSheetName(string candidate) => _sheetNames.Allocate(candidate, MaxSheetNameLength);
 
     private void ReorderSheets()
     {

--- a/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/UniqueNameAllocatorTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Report.Tests/Writers/UniqueNameAllocatorTests.cs
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.ProxmoxVE.Report.Writers;
+
+namespace Corsinvest.ProxmoxVE.Report.Tests.Writers;
+
+public class UniqueNameAllocatorTests
+{
+    [Fact]
+    public void Allocate_FirstCall_ReturnsCandidateUnchanged()
+    {
+        var allocator = new UniqueNameAllocator();
+
+        Assert.Equal("nodes/cc01.html", allocator.Allocate("nodes/cc01.html"));
+    }
+
+    [Fact]
+    public void Allocate_SecondCallSameCandidate_GetsSuffix2()
+    {
+        var allocator = new UniqueNameAllocator();
+
+        Assert.Equal("nodes/cc01.html", allocator.Allocate("nodes/cc01.html"));
+        Assert.Equal("nodes/cc01.html_2", allocator.Allocate("nodes/cc01.html"));
+    }
+
+    [Fact]
+    public void Allocate_ThirdCall_GetsSuffix3()
+    {
+        var allocator = new UniqueNameAllocator();
+
+        allocator.Allocate("Cluster");
+        allocator.Allocate("Cluster");
+        Assert.Equal("Cluster_3", allocator.Allocate("Cluster"));
+    }
+
+    [Fact]
+    public void Allocate_DistinctCandidates_AreIndependent()
+    {
+        var allocator = new UniqueNameAllocator();
+
+        Assert.Equal("a", allocator.Allocate("a"));
+        Assert.Equal("b", allocator.Allocate("b"));
+        Assert.Equal("a_2", allocator.Allocate("a"));
+        Assert.Equal("b_2", allocator.Allocate("b"));
+    }
+
+    [Fact]
+    public void Allocate_LiteralSuffixedNameAfterBase_SkipsCollision()
+    {
+        // Edge case: "cc01" is taken, then someone asks for the literal "cc01_2".
+        // The allocator must hand out "cc01_2" exactly once and then start adding
+        // a NEW suffix when collision happens — never reuse "cc01_2" twice.
+        var allocator = new UniqueNameAllocator();
+
+        Assert.Equal("cc01", allocator.Allocate("cc01"));
+        Assert.Equal("cc01_2", allocator.Allocate("cc01_2"));
+        Assert.Equal("cc01_3", allocator.Allocate("cc01"));    // skips the already-taken cc01_2
+    }
+
+    [Fact]
+    public void Allocate_RespectsCaseInsensitiveComparer()
+    {
+        // XLSX uses OrdinalIgnoreCase because Excel sheet names are case-insensitive.
+        var allocator = new UniqueNameAllocator(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal("Node", allocator.Allocate("Node"));
+        Assert.Equal("node_2", allocator.Allocate("node"));
+    }
+
+    [Fact]
+    public void Allocate_TruncatesToMaxLength_OnFirstCall()
+    {
+        var allocator = new UniqueNameAllocator();
+
+        // Excel sheet-name limit is 31.
+        var result = allocator.Allocate("ThisNameIsLongerThanThirtyOneChars", maxLength: 31);
+
+        Assert.Equal(31, result.Length);
+        Assert.Equal("ThisNameIsLongerThanThirtyOneCh", result);
+    }
+
+    [Fact]
+    public void Allocate_TruncatesPrefixToFitSuffix_OnCollision()
+    {
+        var allocator = new UniqueNameAllocator();
+
+        // 31-char limit with "_2" suffix → prefix must be 29 chars.
+        allocator.Allocate("ThisNameIsLongerThanThirtyOneCh", maxLength: 31);
+        var second = allocator.Allocate("ThisNameIsLongerThanThirtyOneChars", maxLength: 31);
+
+        Assert.Equal(31, second.Length);
+        Assert.EndsWith("_2", second);
+    }
+
+    [Fact]
+    public void Allocate_KnownCollision_NodeWithDotVsDash()
+    {
+        // The real-world bug this helper guards against: two PVE nodes named
+        // "cc.01" and "cc-01" both slug to the same path. The first one wins;
+        // the second one gets a numeric suffix.
+        var allocator = new UniqueNameAllocator();
+        const string slugged = "nodes/cc-01.html";
+
+        Assert.Equal("nodes/cc-01.html", allocator.Allocate(slugged));
+        Assert.Equal("nodes/cc-01.html_2", allocator.Allocate(slugged));
+    }
+}


### PR DESCRIPTION
## Summary

Three writer fixes user-visible in HTML/JSON output, plus a small refactor that pulls the dedup logic out of \`XlsxReportWriter\` into a reusable helper.

## What changes for the user

- **Hostnames with dashes are kept in HTML and JSON file names.** A node called \`pve-host01\` used to produce \`pvehost01.html\` and \`pvehost01.json\` — the dash was dropped. The file name now matches the hostname.
- **Links between HTML pages now work.** Clicking a node, VM or container in an overview table opened a 404 instead of the matching detail page (the link rendered the raw section name, e.g. \`href=\"CT 100\"\`, instead of \`href=\"containers/100.html\"\`). All cross-section hyperlinks now resolve to the actual file path.
- **Two nodes with similar names no longer share the same report page.** When two nodes ended up with the same file name (e.g. \`cc.01\` and \`cc-01\`), the second one used to overwrite the first one's HTML/JSON file silently. Each section now gets its own file (XLSX already handled this for sheet names — HTML/JSON are catching up).

## What changes under the hood

- New \`Writers/UniqueNameAllocator\` — writer-agnostic deduplication. Each writer instantiates its own allocator because the collision domain differs (sheet names are 31-char case-insensitive; file paths are open-ended case-sensitive).
- \`XlsxReportWriter\` refactored to delegate to the new allocator with \`maxLength=31\`. Behaviour unchanged.
- \`HtmlReportWriter\` / \`JsonReportWriter\` now allocate the section file name at \`AddSection\` time, rewrite their \`Links[]\` entries to the final file path, and use that value directly when rendering hyperlinks.
- Slug routine now keeps existing dashes alongside letters and digits.

## Tests

- 9 new \`UniqueNameAllocatorTests\` covering basic alloc / suffix-2 / suffix-3, distinct candidates, the suffix-skip edge case (\"cc01_2\" arriving after \"cc01\"), the case-insensitive comparer, and the truncate-prefix-to-fit-suffix behaviour for length-bounded targets.
- Full suite: 50 tests passing on net8 / net9 / net10.

## Test plan

- [x] \`dotnet test\` green on net8 / net9 / net10
- [x] Locally verified: node detail links in HTML overview tables resolve to the correct file
- [ ] CI green on GitHub Actions